### PR TITLE
Type inference

### DIFF
--- a/scripts/abs.wscl
+++ b/scripts/abs.wscl
@@ -1,0 +1,1 @@
+pub let abs(x: i32) -> i32 = if x < 0 { -x } else { x };

--- a/scripts/assoc.wscl
+++ b/scripts/assoc.wscl
@@ -1,0 +1,1 @@
+pub let hello(x: i32) = x / 10 * 20

--- a/scripts/coerce.wscl
+++ b/scripts/coerce.wscl
@@ -1,0 +1,10 @@
+
+pub let coerce2_i64() -> i64 = {
+    let x = 42;
+    x
+}
+
+pub let coerce2_f32() -> f32 = {
+    let x = 3.14;
+    x
+}

--- a/scripts/cond.wscl
+++ b/scripts/cond.wscl
@@ -1,1 +1,1 @@
-pub let hello(x, y, z) = if x < 0 { y } else { z };
+pub let hello(x: i32, y: i32, z: i32) = if x < 0 { y } else { z };

--- a/scripts/convert.wscl
+++ b/scripts/convert.wscl
@@ -1,0 +1,1 @@
+pub let hello(x: i32) -> f64 = x as f64 * 1.5

--- a/scripts/fact.wscl
+++ b/scripts/fact.wscl
@@ -1,4 +1,4 @@
-pub let fact(x) = if x < 2 {
+pub let fact(x: i32) = if x < 2 {
     1
 } else {
     fact(x - 1) * x

--- a/scripts/fibo.wscl
+++ b/scripts/fibo.wscl
@@ -1,4 +1,4 @@
-pub let fibo(x) = if x < 2 {
+pub let fibo(x: i32) -> i32 = if x < 2 {
     1
 } else {
     fibo(x - 1) + fibo(x - 2)

--- a/scripts/funcs.wscl
+++ b/scripts/funcs.wscl
@@ -1,4 +1,4 @@
-let t(s: i32) = {
+let t(s: i32) -> i32 = {
     let v = s * 2;
     v * 2
 }

--- a/scripts/funcs.wscl
+++ b/scripts/funcs.wscl
@@ -1,6 +1,6 @@
-let t(s) = {
+let t(s: i32) = {
     let v = s * 2;
     v * 2
 }
 
-pub let hello(x, y, z) = t(x) / y + z;
+pub let hello(x: i32, y: i32, z: i32) = t(x) / y + z;

--- a/scripts/hello.wscl
+++ b/scripts/hello.wscl
@@ -1,1 +1,1 @@
-pub let hello(x: i64, y: i64) = x * 10 + y
+pub let hello(x: i32, y: i32) = x * 10 + y

--- a/scripts/hello.wscl
+++ b/scripts/hello.wscl
@@ -1,1 +1,1 @@
-pub let hello(x, y) = x * 10 + y
+pub let hello(x: i64, y: i64) = x * 10 + y

--- a/scripts/log.wscl
+++ b/scripts/log.wscl
@@ -1,4 +1,4 @@
-pub let main(x) = {
+pub let main(x: i32) -> i32 = {
     log(x + 42);
-    42
+    x
 }

--- a/scripts/loop.wscl
+++ b/scripts/loop.wscl
@@ -1,4 +1,4 @@
-pub let loop(x) = {
+pub let loop(x: i32) -> i32 = {
     let ret = 0;
     for i in 1 to x {
         ret = ret + i;

--- a/scripts/loop.wscl
+++ b/scripts/loop.wscl
@@ -1,4 +1,4 @@
-pub let loop(x: i32) -> i32 = {
+pub let loop(x: i64) -> i32 = {
     let ret = 0;
     for i in 1 to x {
         ret = ret + i;

--- a/scripts/loop.wscl
+++ b/scripts/loop.wscl
@@ -1,8 +1,10 @@
-pub let loop(x: i64) -> i32 = {
+let loop(x: i64) -> i32 = {
     let ret = 0;
     for i in 1 to x {
         ret = ret + i;
-        log(ret);
+        log(ret as i32);
     }
-    ret
+    ret as i32
 }
+
+pub let main(x: i32) -> i32 = loop(x as i64);

--- a/scripts/mandel.wscl
+++ b/scripts/mandel.wscl
@@ -1,4 +1,4 @@
-let printdensity(d) = {
+let printdensity(d: i32) -> i32 = {
   if d > 127 {
     putc(32)
   } else if d > 8 {
@@ -10,7 +10,7 @@ let printdensity(d) = {
   }
 }
 
-let mandelconverge(creal: f64, cimag: f64) = {
+let mandelconverge(creal: f64, cimag: f64) -> i32 = {
     let r: f64 = creal;
     let i: f64 = cimag;
     for iter in 0 to 255 {
@@ -24,21 +24,15 @@ let mandelconverge(creal: f64, cimag: f64) = {
     iter
 }
 
-let radius(r: f64, i: f64) = {
-    if r*r + i*i > 2. {
-        255
-    } else {
-        0
-    }
-}
-
-let mandel(xmin: f64, ymin: f64, xstep: f64, ystep: f64, xsteps: f64, ysteps: f64) = {
+let mandel(xmin: f64, ymin: f64, xstep: f64, ystep: f64, xsteps: f64, ysteps: f64) -> i32 = {
     let xmax: f64 = xmin + xstep * xsteps;
     let ymax: f64 = ymin + ystep * ysteps;
-    for iy in 0 to ysteps {
-        let y: f64 = iy * (ymax - ymin) * ystep + ymin;
-        for ix in 0 to xsteps {
-            let x: f64 = ix * (xmax - xmin) * xstep + xmin;
+    let ixsteps: i32 = xsteps as i32;
+    let iysteps: i32 = ysteps as i32;
+    for iy in 0 to iysteps {
+        let y: f64 = iy as f64 * (ymax - ymin) * ystep + ymin;
+        for ix in 0 to ixsteps {
+            let x: f64 = ix as f64 * (xmax - xmin) * xstep + xmin;
             printdensity(mandelconverge(x,y));
         }
         putc(10);

--- a/scripts/mandel_highres.wscl
+++ b/scripts/mandel_highres.wscl
@@ -1,4 +1,4 @@
-let printdensity(d) = {
+let printdensity(d: i32) -> i32 = {
   if d > 127 {
     putc(32)
   } else if d > 8 {
@@ -10,7 +10,7 @@ let printdensity(d) = {
   }
 }
 
-let mandelconverge(creal: f64, cimag: f64) = {
+let mandelconverge(creal: f64, cimag: f64) -> i32 = {
     let r: f64 = creal;
     let i: f64 = cimag;
     for iter in 0 to 255 {
@@ -24,20 +24,14 @@ let mandelconverge(creal: f64, cimag: f64) = {
     iter
 }
 
-let radius(r: f64, i: f64) = {
-    if r*r + i*i > 2. {
-        255
-    } else {
-        0
-    }
-}
-
-let mandel(xmin: f64, ymin: f64, xstep: f64, ystep: f64, xsteps: f64, ysteps: f64) = {
+let mandel(xmin: f64, ymin: f64, xstep: f64, ystep: f64, xsteps: f64, ysteps: f64) -> i32 = {
     let xmax: f64 = xmin + xstep * xsteps;
     let ymax: f64 = ymin + ystep * ysteps;
-    for iy in 0 to ysteps {
+    let ixsteps: i32 = xsteps;
+    let iysteps: i32 = ysteps;
+    for iy in 0 to iysteps {
         let y: f64 = iy * (ymax - ymin) * ystep + ymin;
-        for ix in 0 to xsteps {
+        for ix in 0 to ixsteps {
             let x: f64 = ix * (xmax - xmin) * xstep + xmin;
             printdensity(mandelconverge(x,y));
         }

--- a/scripts/mandel_highres.wscl
+++ b/scripts/mandel_highres.wscl
@@ -27,12 +27,12 @@ let mandelconverge(creal: f64, cimag: f64) -> i32 = {
 let mandel(xmin: f64, ymin: f64, xstep: f64, ystep: f64, xsteps: f64, ysteps: f64) -> i32 = {
     let xmax: f64 = xmin + xstep * xsteps;
     let ymax: f64 = ymin + ystep * ysteps;
-    let ixsteps: i32 = xsteps;
-    let iysteps: i32 = ysteps;
+    let ixsteps: i32 = xsteps as i32;
+    let iysteps: i32 = ysteps as i32;
     for iy in 0 to iysteps {
-        let y: f64 = iy * (ymax - ymin) * ystep + ymin;
+        let y: f64 = iy as f64 * (ymax - ymin) * ystep + ymin;
         for ix in 0 to ixsteps {
-            let x: f64 = ix * (xmax - xmin) * xstep + xmin;
+            let x: f64 = ix as f64 * (xmax - xmin) * xstep + xmin;
             printdensity(mandelconverge(x,y));
         }
         putc(10);

--- a/scripts/paren.wscl
+++ b/scripts/paren.wscl
@@ -1,0 +1,1 @@
+pub let main(x: i32, y: i32) = x * (10 + y)

--- a/scripts/putc.wscl
+++ b/scripts/putc.wscl
@@ -1,4 +1,4 @@
-pub let main(x) = {
+pub let main(x: i32) = {
     putc(x);
     x
 }

--- a/scripts/zerodiv.wscl
+++ b/scripts/zerodiv.wscl
@@ -1,1 +1,1 @@
-pub let hello() = 0 / 0;
+pub let hello() -> i32 = 0 / 0;

--- a/src/infer.rs
+++ b/src/infer.rs
@@ -1,0 +1,208 @@
+//! Implementation of type inference using TypeSet
+
+use std::{collections::HashMap, sync::Condvar};
+
+use crate::{
+    model::TypeSet,
+    parser::{Expression, Statement},
+    Type,
+};
+
+#[derive(Debug, PartialEq)]
+pub struct TypeInferFn {
+    pub(crate) params: Vec<Type>,
+    pub(crate) ret_ty: TypeSet,
+}
+
+pub fn get_type_infer_fns(stmt: &Statement, funcs: &mut HashMap<String, TypeInferFn>) {
+    match stmt {
+        Statement::FnDecl(fn_decl) => {
+            funcs.insert(
+                fn_decl.name.to_string(),
+                TypeInferFn {
+                    params: fn_decl
+                        .params
+                        .iter()
+                        .map(|p| p.ty.determine().unwrap())
+                        .collect(),
+                    ret_ty: fn_decl.ret_ty,
+                },
+            );
+        }
+        _ => {}
+    }
+}
+
+pub struct TypeInferer<'a> {
+    funcs: &'a HashMap<String, TypeInferFn>,
+    locals: HashMap<String, TypeSet>,
+}
+
+impl<'a> TypeInferer<'a> {
+    pub fn new(funcs: &'a HashMap<String, TypeInferFn>) -> Self {
+        Self {
+            funcs,
+            locals: HashMap::new(),
+        }
+    }
+
+    pub fn infer_type_expr(&mut self, ex: &Expression) -> Result<TypeSet, String> {
+        match ex {
+            Expression::LiteralInt(_, ts) => Ok(*ts),
+            Expression::LiteralFloat(_, ts) => Ok(*ts),
+            Expression::Variable(name) => Ok(self
+                .locals
+                .get(*name)
+                .copied()
+                .unwrap_or(TypeSet::default())),
+            Expression::FnInvoke(name, _) => {
+                Ok(self.funcs.get(*name).map_or(TypeSet::ALL, |f| f.ret_ty))
+            }
+            Expression::Add(lhs, rhs)
+            | Expression::Sub(lhs, rhs)
+            | Expression::Mul(lhs, rhs)
+            | Expression::Div(lhs, rhs) => {
+                let lhs_ty = self.infer_type_expr(lhs)?;
+                let rhs_ty = self.infer_type_expr(rhs)?;
+                Ok(lhs_ty & rhs_ty)
+            }
+            Expression::Lt(_, _) | Expression::Gt(_, _) => {
+                // Relation operators always return i32 (boolean)
+                Ok(Type::I32.into())
+            }
+            Expression::Conditional(_, t_branch, f_branch) => {
+                let t_ty = t_branch
+                    .last()
+                    .map_or(Ok(TypeSet::default()), |stmt| self.forward_type_stmt(stmt))?;
+                let f_ty = f_branch.as_ref().map_or(Ok(TypeSet::default()), |stmts| {
+                    stmts
+                        .last()
+                        .map_or(Ok(TypeSet::default()), |stmt| self.forward_type_stmt(stmt))
+                })?;
+                Ok(t_ty & f_ty)
+            }
+            _ => Ok(Type::Void.into()),
+        }
+    }
+
+    fn propagate_type_expr(&mut self, ex: &mut Expression, ts: &TypeSet) {
+        match ex {
+            Expression::LiteralInt(_, target_ts) => *target_ts = dbg!(*ts),
+            Expression::LiteralFloat(_, target_ts) => *target_ts = *ts,
+            Expression::Variable(var) => {
+                if let Some(var) = self.locals.get_mut(*var) {
+                    *var = *ts;
+                }
+            }
+            Expression::Add(lhs, rhs)
+            | Expression::Sub(lhs, rhs)
+            | Expression::Mul(lhs, rhs)
+            | Expression::Div(lhs, rhs) => {
+                self.propagate_type_expr(lhs, ts);
+                self.propagate_type_expr(rhs, ts);
+            }
+            Expression::Lt(lhs, rhs)
+            | Expression::Gt(lhs, rhs) => {
+                println!("propagate_type_expr");
+                self.propagate_type_expr(lhs, &Type::I32.into());
+                self.propagate_type_expr(rhs, &Type::I32.into());
+            }
+            Expression::Conditional(cond, t_branch, f_branch) => {
+                self.propagate_type_expr(cond, &Type::I32.into());
+                if let Some(t_stmt) = t_branch
+                    .last_mut() {
+                    self.propagate_type_stmt(t_stmt, ts);
+                }
+                if let Some(f_stmt) = f_branch.as_mut().and_then(|stmts| stmts.last_mut()) {
+                    self.propagate_type_stmt(f_stmt, ts);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn propagate_type_stmt(&mut self, stmt: &mut Statement, ts: &TypeSet) {
+        match stmt {
+            Statement::VarDecl(name, decl_ty, ex) => {
+                if let Some(&var_ts) = self.locals.get(*name) {
+                    self.propagate_type_expr(ex, dbg!(&var_ts));
+                    *decl_ty = var_ts;
+                }
+            }
+            Statement::Expr(ex) => self.propagate_type_expr(ex, ts),
+            Statement::Brace(stmts) => {
+                if let Some(stmt) = stmts.last_mut() {
+                    self.propagate_type_stmt(stmt, dbg!(ts));
+                }
+                for stmt in stmts.iter_mut().rev().skip(1) {
+                    self.propagate_type_stmt(stmt, &TypeSet::default());
+                }
+            }
+            Statement::FnDecl(fn_decl) => {
+                for stmt in fn_decl.stmts.iter_mut().rev() {
+                    self.propagate_type_stmt(stmt, &TypeSet::default());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn forward_type_stmt(&mut self, stmt: &Statement) -> Result<TypeSet, String> {
+        match stmt {
+            Statement::Expr(ex) => self.infer_type_expr(dbg!(ex)),
+            Statement::Brace(stmts) => {
+                let mut last_ty = TypeSet::default();
+                for stmt in stmts {
+                    last_ty = self.forward_type_stmt(stmt)?;
+                }
+                Ok(last_ty)
+            }
+            _ => Ok(TypeSet::default()),
+        }
+    }
+
+    pub fn infer_type_stmt(&mut self, stmt: &mut Statement) -> Result<(), String> {
+        match stmt {
+            Statement::VarDecl(name, ty, ex) => {
+                let ex_ty = dbg!(self.infer_type_expr(ex)?);
+                let inferred_ty = dbg!(ex_ty & TypeSet::from(*ty));
+                if let Some(determined_ty) = inferred_ty.determine() {
+                    // .ok_or_else(|| "Type could not be determined".to_string())?;
+                    let determined_ts = TypeSet::from(determined_ty);
+                    self.propagate_type_expr(ex, &determined_ts);
+                }
+                self.locals.insert(name.to_string(), inferred_ty);
+                Ok(())
+            }
+            Statement::FnDecl(fn_decl) => {
+                let mut inferer = TypeInferer::new(self.funcs);
+                inferer.locals = fn_decl
+                    .params
+                    .iter()
+                    .map(|param| (param.name.clone(), param.ty))
+                    .collect();
+                let mut last_ty = TypeSet::default();
+                for stmt in &mut fn_decl.stmts {
+                    last_ty = inferer.forward_type_stmt(stmt)?;
+                    println!("stmt {stmt:?} ty {last_ty}");
+                }
+                dbg!(last_ty);
+                if let Some(determined_ty) = (last_ty & fn_decl.ret_ty.into()).determine() {
+                    let determined_ts = TypeSet::from(determined_ty);
+                    dbg!(determined_ty);
+                    fn_decl.ret_ty = determined_ts;
+                    for stmt in fn_decl.stmts.iter_mut().rev() {
+                        inferer.propagate_type_stmt(stmt, &determined_ts);
+                    }
+                } else {
+                    println!(
+                        "Function return type could not be determined: {}",
+                        last_ty & fn_decl.ret_ty.into()
+                    );
+                }
+                Ok(())
+            }
+            _ => Ok(()),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod compiler;
+mod infer;
 mod model;
 mod parser;
 mod wasm_file;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod compiler;
+mod infer;
 mod model;
 mod parser;
 mod wasm_file;

--- a/src/model.rs
+++ b/src/model.rs
@@ -61,6 +61,154 @@ impl std::fmt::Display for Type {
     }
 }
 
+#[derive(Default, Debug, Clone, Copy, PartialEq)]
+pub struct TypeSet {
+    pub i32: bool,
+    pub i64: bool,
+    pub f32: bool,
+    pub f64: bool,
+}
+
+impl TypeSet {
+    pub const I32: Self = Self {
+        i32: true,
+        i64: false,
+        f32: false,
+        f64: false,
+    };
+    pub const I64: Self = Self {
+        i32: false,
+        i64: true,
+        f32: false,
+        f64: false,
+    };
+    pub const F32: Self = Self {
+        i32: false,
+        i64: false,
+        f32: true,
+        f64: false,
+    };
+    pub const F64: Self = Self {
+        i32: false,
+        i64: false,
+        f32: false,
+        f64: true,
+    };
+    pub const ALL: Self = Self {
+        i32: true,
+        i64: true,
+        f32: true,
+        f64: true,
+    };
+
+    pub fn is_none(&self) -> bool {
+        !self.i32 && !self.i64 && !self.f32 && !self.f64
+    }
+
+    pub fn determine(&self) -> Option<Type> {
+        match self {
+            TypeSet {
+                i32: true,
+                i64: false,
+                f32: false,
+                f64: false,
+            } => Some(Type::I32),
+            TypeSet {
+                i32: false,
+                i64: true,
+                f32: false,
+                f64: false,
+            } => Some(Type::I64),
+            TypeSet {
+                i32: false,
+                i64: false,
+                f32: true,
+                f64: false,
+            } => Some(Type::F32),
+            TypeSet {
+                i32: false,
+                i64: false,
+                f32: false,
+                f64: true,
+            } => Some(Type::F64),
+            _ => None,
+        }
+    }
+}
+
+impl std::ops::BitOr for TypeSet {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self::Output {
+        Self {
+            i32: self.i32 | rhs.i32,
+            i64: self.i64 | rhs.i64,
+            f32: self.f32 | rhs.f32,
+            f64: self.f64 | rhs.f64,
+        }
+    }
+}
+
+impl std::ops::BitAnd for TypeSet {
+    type Output = Self;
+    fn bitand(self, rhs: Self) -> Self::Output {
+        Self {
+            i32: self.i32 & rhs.i32,
+            i64: self.i64 & rhs.i64,
+            f32: self.f32 & rhs.f32,
+            f64: self.f64 & rhs.f64,
+        }
+    }
+}
+
+impl From<Type> for TypeSet {
+    fn from(value: Type) -> Self {
+        let mut ret = Self::default();
+        match value {
+            Type::I32 => ret.i32 = true,
+            Type::I64 => ret.i64 = true,
+            Type::F32 => ret.f32 = true,
+            Type::F64 => ret.f64 = true,
+            _ => {}
+        }
+        ret
+    }
+}
+
+impl std::fmt::Display for TypeSet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut written = false;
+        if self.i32 {
+            write!(f, "i32")?;
+            written = true;
+        }
+        if self.i64 {
+            if written {
+                write!(f, "|")?;
+            }
+            write!(f, "i64")?;
+            written = true;
+        }
+        if self.f32 {
+            if written {
+                write!(f, "|")?;
+            }
+            write!(f, "f32")?;
+            written = true;
+        }
+        if self.f64 {
+            if written {
+                write!(f, "|")?;
+            }
+            write!(f, "f64")?;
+            written = true;
+        }
+        if !written {
+            write!(f, "void")?;
+        }
+        Ok(())
+    }
+}
+
 pub struct FuncType {
     pub params: Vec<Type>,
     pub results: Vec<Type>,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -88,13 +88,13 @@ fn num_literal(mut input: &str) -> Result<(&str, Expression), String> {
 
 #[test]
 fn test_uneg() {
-    assert!(matches!(
+    assert_eq!(
         num_literal("-2.5"),
         Ok((
             "",
             Expression::LiteralFloat(-2.5, TypeSet::F32 | TypeSet::F64)
         ))
-    ));
+    );
 }
 
 fn advance_char(input: &str) -> &str {
@@ -199,13 +199,13 @@ fn postfix_as<'a>(expr: Expression<'a>, i: &'a str) -> IResult<&'a str, Expressi
 fn factor(i: &str) -> Result<(&str, Expression), String> {
     let r = space(i);
 
+    if let Ok((r, val)) = num_literal(r) {
+        return Ok((r, val));
+    }
+
     if let Ok((r, _)) = recognize("-")(r) {
         let (r, val) = factor(r)?;
         return Ok((r, Expression::Neg(Box::new(val))));
-    }
-
-    if let Ok((r, val)) = num_literal(r) {
-        return Ok((r, val));
     }
 
     if let Ok((r, _)) = recognize("(")(r) {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,9 +1,9 @@
-use crate::model::Type;
+use crate::model::{Type, TypeSet};
 
 #[derive(Debug, PartialEq)]
 pub enum Expression<'src> {
-    LiteralI32(i32),
-    LiteralF64(f64),
+    LiteralInt(i64, TypeSet),
+    LiteralFloat(f64, TypeSet),
     Variable(&'src str),
     FnInvoke(&'src str, Vec<Expression<'src>>),
     Neg(Box<Expression<'src>>),
@@ -22,7 +22,7 @@ pub enum Expression<'src> {
 
 #[derive(Debug, PartialEq)]
 pub enum Statement<'src> {
-    VarDecl(&'src str, Type, Expression<'src>),
+    VarDecl(&'src str, TypeSet, Expression<'src>),
     VarAssign(&'src str, Expression<'src>),
     Expr(Expression<'src>),
     FnDecl(FnDecl<'src>),
@@ -36,7 +36,7 @@ pub struct FnDecl<'src> {
     pub(crate) name: &'src str,
     pub(crate) params: Vec<VarDecl>,
     pub(crate) stmts: Vec<Statement<'src>>,
-    pub(crate) ret_ty: Type,
+    pub(crate) ret_ty: TypeSet,
     pub(crate) public: bool,
 }
 
@@ -46,7 +46,7 @@ pub struct FnDecl<'src> {
 #[derive(Debug, Clone, PartialEq)]
 pub struct VarDecl {
     pub(crate) name: String,
-    pub(crate) ty: Type,
+    pub(crate) ty: TypeSet,
 }
 
 #[derive(Debug, PartialEq)]
@@ -69,10 +69,16 @@ fn num_literal(mut input: &str) -> Result<(&str, Expression), String> {
         let slice = &start[..(input.as_ptr() as usize - start.as_ptr() as usize)];
         if slice.contains('.') {
             let num = slice.parse::<f64>().map_err(|s| s.to_string())?;
-            Ok((input, Expression::LiteralF64(num)))
+            Ok((
+                input,
+                Expression::LiteralFloat(num, TypeSet::F32 | TypeSet::F64),
+            ))
         } else {
-            let num = slice.parse::<i32>().map_err(|s| s.to_string())?;
-            Ok((input, Expression::LiteralI32(num)))
+            let num = slice.parse::<i64>().map_err(|s| s.to_string())?;
+            Ok((
+                input,
+                Expression::LiteralInt(num, TypeSet::I32 | TypeSet::I64),
+            ))
         }
     } else {
         Err("Not a number".to_string())
@@ -83,7 +89,10 @@ fn num_literal(mut input: &str) -> Result<(&str, Expression), String> {
 fn test_uneg() {
     assert!(matches!(
         num_literal("-2.5"),
-        Ok(("", Expression::LiteralF64(-2.5)))
+        Ok((
+            "",
+            Expression::LiteralFloat(-2.5, TypeSet::F32 | TypeSet::F64)
+        ))
     ));
 }
 
@@ -377,9 +386,9 @@ fn decl_ty(i: &str) -> IResult<&str, Type> {
 fn fn_param(i: &str) -> IResult<&str, VarDecl> {
     let (r, param_name) = identifier(space(i))?;
     let (r, ty) = if let Ok((r, ty)) = decl_ty(space(r)) {
-        (r, ty)
+        (r, ty.into())
     } else {
-        (r, Type::I32)
+        (r, TypeSet::ALL)
     };
     Ok((
         r,
@@ -407,7 +416,6 @@ fn let_binding(i: &str) -> IResult<&str, Statement> {
     };
     let (r, _) = recognize("let")(r)?;
     let (r, name) = identifier(space1(r)?)?;
-    dbg!(public, name);
 
     if let Ok((mut r, _)) = recognize("(")(space(r)) {
         let mut params = vec![];
@@ -430,7 +438,7 @@ fn let_binding(i: &str) -> IResult<&str, Statement> {
             );
         };
 
-        let (r, ret_ty) = fn_ret_ty(r).unwrap_or((r, Type::I32));
+        let (r, ret_ty) = fn_ret_ty(r).map_or((r, TypeSet::ALL), |(r, ty)| (r, TypeSet::from(ty)));
 
         let Ok((r, _)) = recognize("=")(space(r)) else {
             return Err("Syntax error in func decl: = could not be found".to_string());
@@ -450,7 +458,7 @@ fn let_binding(i: &str) -> IResult<&str, Statement> {
         ));
     }
 
-    let (r, ty) = decl_ty(r).unwrap_or((r, Type::I32));
+    let (r, ty) = decl_ty(r).map_or((r, TypeSet::ALL), |(r, ty)| (r, ty.into()));
 
     let Ok((r, _)) = recognize("=")(space(r)) else {
         return Err("Syntax error in var decl".to_string());

--- a/src/wasm_file.rs
+++ b/src/wasm_file.rs
@@ -89,7 +89,10 @@ fn codegen(
             import_fn.name.clone(),
             TypeInferFn {
                 params: func_ty.params.clone(),
-                ret_ty: func_ty.results[0].into(),
+                ret_ty: func_ty
+                    .results
+                    .get(0)
+                    .map_or(TypeSet::default(), |v| (*v).into()),
             },
         );
     }

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -97,8 +97,36 @@ let x: i32 = 42;
             </pre>
 
             <p>
-            If the type is omitted, it is assumed to be <tt>i32</tt>.
+            If the type is omitted, the type is inferred.
+            However, note that the variable has to be constrained by an expression somewhere in the function, otherwise
+            the type inference fails with an ambiguous type.
+            So the function below is ok:
             </p>
+
+            <pre>
+let f() -> i32 = {
+    let x = 42;
+    x
+}
+            </pre>
+
+            <p>
+            but the one below is not, because its type is not bounded by any expression.
+            </p>
+
+            <pre>
+let f() -> i32 = {
+    let x = 42;
+    0
+}
+            </pre>
+
+            <h3>Cast expression</h3>
+            You can cast a type to another with <tt>as</tt> keyword:
+
+            <pre>
+pub let as_i32(x: f64) -> i32 = x as i32;
+            </pre>
 
             <h3>Function definition</h3>
             <p>
@@ -110,7 +138,8 @@ let add(x: i32, y: i32) -> i32 = x + y;
             </pre>
 
             <p>
-            If the types of the parameters or the returned value is omitted, it is assumed to be <tt>i32</tt>.
+            Types of the parameters are required, although this requirement may be lifted in the future.
+            If the return type is omitted, it is inferred from the last expression in the function body.
             </p>
 
             <p>

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -76,6 +76,11 @@
                 <li>f64</li>
             </ul>
 
+            <p>
+            Yes, there are no string types!
+            Since we do not use linear memory yet, we can't handle variable length data, including a string.
+            </p>
+
             <h2>Built-in functions</h2>
 
             <ul>
@@ -195,6 +200,25 @@ for i in 1 to x {
     if 10 &lt; i {
         break
     };
+}
+            </pre>
+
+            <h3>Return statement</h3>
+            Return statement lets you exit the function early.
+
+            <pre>
+let mandelconverge(creal: f64, cimag: f64) -> i32 = {
+    let r: f64 = creal;
+    let i: f64 = cimag;
+    for iter in 0 to 255 {
+        if r*r + i*i > 4. {
+            return iter;
+        };
+        let next_r: f64 = r * r - i * i + creal;
+        i = 2. * r * i + cimag;
+        r = next_r;
+    }
+    iter
 }
             </pre>
 

--- a/wasm/js/main.js
+++ b/wasm/js/main.js
@@ -130,7 +130,7 @@ document.getElementById("clearCanvas").addEventListener("click", () => {
 });
 
 document.getElementById("input").value = `
-let hello(x, y) = x + y;
+pub let hello(x: i32, y: i32) = x + y;
 `;
 
 const samples = document.getElementById("samples");

--- a/wasm/scripts/canvas.wscl
+++ b/wasm/scripts/canvas.wscl
@@ -1,4 +1,4 @@
-pub let main() = {
+pub let main() -> i32 = {
     for y in 0 to 10 {
         for x in 0 to 13 {
             set_fill_style(x * 20, y * 25, 127);

--- a/wasm/scripts/mandel_canvas.wscl
+++ b/wasm/scripts/mandel_canvas.wscl
@@ -1,4 +1,4 @@
-let printdensity(d) = {
+let printdensity(d: i32) -> i32 = {
   if d > 127 {
     putc(32)
   } else if d > 8 {
@@ -10,7 +10,7 @@ let printdensity(d) = {
   }
 }
 
-let mandelconverge(creal: f64, cimag: f64) = {
+let mandelconverge(creal: f64, cimag: f64) -> i32 = {
     let r: f64 = creal;
     let i: f64 = cimag;
     for iter in 0 to 255 {
@@ -21,18 +21,18 @@ let mandelconverge(creal: f64, cimag: f64) = {
         i = 2. * r * i + cimag;
         r = next_r;
     }
-    255
+    iter
 }
 
-let mandel(xmin: f64, ymin: f64, xstep: f64, ystep: f64, xsteps: f64, ysteps: f64) = {
+let mandel(xmin: f64, ymin: f64, xstep: f64, ystep: f64, xsteps: f64, ysteps: f64) -> i32 = {
     let xmax: f64 = xmin + xstep * xsteps;
     let ymax: f64 = ymin + ystep * ysteps;
-    let ixsteps: i32 = xsteps;
-    let iysteps: i32 = ysteps;
-    for iy in 0 to ysteps {
-        let y: f64 = iy * (ymax - ymin) * ystep + ymin;
-        for ix in 0 to xsteps {
-            let x: f64 = ix * (xmax - xmin) * xstep + xmin;
+    let ixsteps: i32 = xsteps as i32;
+    let iysteps: i32 = ysteps as i32;
+    for iy in 0 to iysteps {
+        let y: f64 = iy as f64 * (ymax - ymin) * ystep + ymin;
+        for ix in 0 to ixsteps {
+            let x: f64 = ix as f64 * (xmax - xmin) * xstep + xmin;
             set_fill_style(ix * 255 / ixsteps, mandelconverge(x,y), iy * 255 / iysteps);
             rectangle(ix * 2, iy * 2, 2, 2);
         }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -2,6 +2,8 @@ use wasm_bindgen::prelude::*;
 
 use wascal::{compile_wasm, disasm_wasm, parse, FuncImport, FuncType, Type};
 
+use std::io::Write;
+
 #[wasm_bindgen]
 pub fn parse_ast(source: &str) -> Result<String, JsValue> {
     let ast = parse(source).map_err(JsValue::from)?;


### PR DESCRIPTION
# Overview

We implmenet a basic type inference.

WebAssembly runtime has strict runtime types, so every numeric instruction requires specific type as the arguments.
We used type declaration and propagation from declared types, but it's cumbersome to declare all variable types (including function parameters).
So I wanted to try a basic type inference.

One of the simplest example is a variable with omitted type declaration.

```
let f() -> i32 = {
    let x = 42;
    x
}
```

In this sample, `x`'s type is inferred to be `i32`, because it's returned as the last expression.

Another motivating example is a for loop:

```
let loop(x: i64) -> i32 = {
    let ret = 0;
    for i in 1 to x {
        ret = ret + i;
        log(ret as i32);
    }
    ret as i32
}
```

In this example, the loop variable `i`'s type is not clearly stated (we don't have a syntax for that). However, the type inference can identify its type has to be i64 (since it's compared with the end value `x: i64`. It in turn determines the type of `ret` to be `i64`.

# How it works

I'm very new to type inference, so it is my own imagination of how type inference would work.

Basically, every "leaf" of AST now has a `TypeSet` instead of just `Type`:

```rust
#[derive(Default, Debug, Clone, Copy, PartialEq)]
pub struct TypeSet {
    pub i32: bool,
    pub i64: bool,
    pub f32: bool,
    pub f64: bool,
}
```

We scan the AST and assign possible types to each leaf node.
Note that we do not need to keep the type for non-leaf nodes, because they can be computed from child nodes in compile pass.

Also, local variables have `TypeSet` in type inference phase.

```rust
pub struct TypeInferer<'a> {
    // ...
    locals: HashMap<String, TypeSet>,
}
```

They should be narrowed down to only one possibility, otherwise it would be an error with ambiguous type.

## AST traversal method

We scan the AST twice to apply the type inference.
The first pass is bottom-up, to propagate declared types to the greater expressions.
The second pass is top-down, after we identify the types of all local variables, we need to propagate it back to the tree to update the types on the leaves.

We apply type inference only in a function scope. Functional languages can apply it among multiple functions, but we would like to start small. Also, Rust doesn't have type inference among function interfaces, because it tend to be harder to maintain stable API if their types can change by the usage.


## Type cast operator

We also added `as` type cast operator to clarify the conversion operation, as you already saw in the above examples.

# Incompatible change

Since omission of a type declaration means "infer me", it no longer implies `i32`.
Also, function parameters are not subject to inference (yet, at least), so the type declarations for parameters are mandatory now.

Numeric types won't coerce to each other now, so you can't assign a i32 to i64 implicity, for example.
Use `as` operator to clarify the conversion.
