### PR TITLE
Support string types

### DIFF
--- a/header.js
+++ b/header.js
@@ -12,7 +12,7 @@ const opts = {
 };
 
 let obj;
-let memory;
+export let memory;
 export async function init(wasm, moreOpts = {}){
     for (const key in moreOpts) {
         opts[key] = moreOpts[key];
@@ -32,18 +32,18 @@ function addStringToWasm(s) {
     const top = view32[0];
     const textEncoder = new TextEncoder('utf8');
     const encodedString = textEncoder.encode(s);
-    const lengthView = new Uint32Array(obj.instance.exports.memory.buffer, top + 4, 1);
+    const lengthView = new Uint32Array(obj.instance.exports.memory.buffer, top, 1);
     lengthView[0] = encodedString.length;
-    const view8 = new Uint8Array(obj.instance.exports.memory.buffer, top + 8, encodedString.length);
+    const view8 = new Uint8Array(obj.instance.exports.memory.buffer, top + 4, encodedString.length);
     view8.set(encodedString);
-    const newTop = top + Math.floor(4 + encodedString.length + 3 / 4) * 4;
+    const newTop = top + Math.floor(encodedString.length + 3 / 4) * 4;
     view32[0] = newTop;
     return top;
 }
 
 function returnString(s) {
-    const view32 = new Int32Array(obj.instance.exports.memory.buffer, s + 4);
-    const view8 = new Int8Array(obj.instance.exports.memory.buffer, s + 8, view32[0]);
+    const view32 = new Int32Array(obj.instance.exports.memory.buffer, s);
+    const view8 = new Int8Array(obj.instance.exports.memory.buffer, s + 4, view32[0]);
     const textDecoder = new TextDecoder('utf-8');
     return textDecoder.decode(view8);
 }

--- a/header.js
+++ b/header.js
@@ -1,0 +1,39 @@
+let outputBuf = "";
+
+const opts = {
+    console: {
+        log: console.log,
+    },
+    output: {
+        putc: c => {
+            outputBuf += String.fromCharCode(c);
+        }
+    }
+};
+
+let obj;
+export let memory;
+(async () => {
+    obj = await WebAssembly.instantiateStreaming(fetch("wascal.wasm"), opts);
+    memory = obj.instance.exports.memory;
+})();
+
+function addStringToWasm(s) {
+    if (!obj) return;
+    const view32 = new Int32Array(obj.instance.exports.memory.buffer);
+    const top = view32[0];
+    const textEncoder = new TextEncoder('utf8');
+    const encodedString = textEncoder.encode(s);
+    const view8 = new Uint8Array(obj.instance.exports.memory.buffer, top + 4, encodedString.length);
+    view8.set(encodedString);
+    const newTop = top + Math.floor(encodedString.length + 3 / 4) * 4;
+    view32[0] = newTop;
+    return [top, encodedString.length];
+}
+
+function returnString(s) {
+    const view32 = new Int32Array(obj.instance.exports.memory.buffer, s + 4);
+    const view8 = new Int8Array(obj.instance.exports.memory.buffer, s + 8, view32[0]);
+    const textDecoder = new TextDecoder('utf-8');
+    return textDecoder.decode(view8);
+}

--- a/header.js
+++ b/header.js
@@ -36,7 +36,7 @@ function addStringToWasm(s) {
     lengthView[0] = encodedString.length;
     const view8 = new Uint8Array(obj.instance.exports.memory.buffer, top + 4, encodedString.length);
     view8.set(encodedString);
-    const newTop = top + Math.floor(encodedString.length + 3 / 4) * 4;
+    const newTop = top + 4 + Math.floor(encodedString.length + 3 / 4) * 4;
     view32[0] = newTop;
     return top;
 }

--- a/header.js
+++ b/header.js
@@ -1,4 +1,4 @@
-export let outputBuf = "";
+let outputBuf = "";
 
 const opts = {
     console: {
@@ -12,11 +12,11 @@ const opts = {
 };
 
 let obj;
-export let memory;
-(async () => {
-    obj = await WebAssembly.instantiateStreaming(fetch("wascal.wasm"), opts);
+let memory;
+export async function init(wasm){
+    obj = await WebAssembly.instantiateStreaming(wasm, opts);
     memory = obj.instance.exports.memory;
-})();
+}
 
 function addStringToWasm(s) {
     if (!obj) return;

--- a/header.js
+++ b/header.js
@@ -24,11 +24,13 @@ function addStringToWasm(s) {
     const top = view32[0];
     const textEncoder = new TextEncoder('utf8');
     const encodedString = textEncoder.encode(s);
-    const view8 = new Uint8Array(obj.instance.exports.memory.buffer, top + 4, encodedString.length);
+    const lengthView = new Uint32Array(obj.instance.exports.memory.buffer, top + 4, 1);
+    lengthView[0] = encodedString.length;
+    const view8 = new Uint8Array(obj.instance.exports.memory.buffer, top + 8, encodedString.length);
     view8.set(encodedString);
-    const newTop = top + Math.floor(encodedString.length + 3 / 4) * 4;
+    const newTop = top + Math.floor(4 + encodedString.length + 3 / 4) * 4;
     view32[0] = newTop;
-    return [top, encodedString.length];
+    return top;
 }
 
 function returnString(s) {

--- a/header.js
+++ b/header.js
@@ -13,8 +13,16 @@ const opts = {
 
 let obj;
 let memory;
-export async function init(wasm){
-    obj = await WebAssembly.instantiateStreaming(wasm, opts);
+export async function init(wasm, moreOpts = {}){
+    for (const key in moreOpts) {
+        opts[key] = moreOpts[key];
+    }
+    if (wasm instanceof Promise) {
+        obj = await WebAssembly.instantiateStreaming(wasm, opts);
+    }
+    else {
+        obj = await WebAssembly.instantiate(wasm, opts);
+    }
     memory = obj.instance.exports.memory;
 }
 

--- a/header.js
+++ b/header.js
@@ -1,4 +1,4 @@
-let outputBuf = "";
+export let outputBuf = "";
 
 const opts = {
     console: {

--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@ window.addEventListener("load", () => {
             }
             const output = document.getElementById('output');
             const res = expFunc.apply(this, args);
-            const view32 = new Int32Array(obj.instance.exports.memory.buffer, res);
+            const view32 = new Int32Array(obj.instance.exports.memory.buffer, res + 4);
             const textDecoder = new TextDecoder('utf-8');
             const decoded = textDecoder.decode(view32);
             output.innerHTML = decoded;

--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@ window.addEventListener("load", () => {
             const argElems = functionElems[expName];
             let args = [];
             for (let i = 0; i < expFunc.length; i++) {
-                if (i < 2) {
+                if (expName !== "malloc" && i < 2) {
                     args.push(addedString[i]);
                 }
                 else {

--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@ window.addEventListener("load", () => {
             }
             const output = document.getElementById('output');
             const res = expFunc.apply(this, args);
-            const view32 = new Int32Array(obj.instance.exports.memory.buffer, res + 4);
+            const view32 = new Int32Array(obj.instance.exports.memory.buffer, res);
             const textDecoder = new TextDecoder('utf-8');
             const decoded = textDecoder.decode(view32);
             output.innerHTML = decoded;

--- a/index.html
+++ b/index.html
@@ -48,8 +48,10 @@ window.addEventListener("load", () => {
         }
     };
 
-    const load = document.getElementById("load");
-    load.addEventListener("click", async () => {
+    const load = document.getElementById("reload");
+    load.addEventListener("click", () => location.reload());
+
+    (async () => {
         console.log("Loading wasm");
         try {
             implib = await import("./wascal.js");
@@ -92,8 +94,8 @@ window.addEventListener("load", () => {
             functions.appendChild(funcElem);
             functionElems[expName] = argElems;
         }
-    });
-    
+    })();
+
     const callFunc = expName => async () => {
         const expFunc = implib[expName];
         console.log("Calling wasm");
@@ -123,7 +125,7 @@ window.addEventListener("load", () => {
     </head>
     <body>
         <h1>Wascal</h1>
-        <button id="load">Load wasm module</button>
+        <button id="reload">Reload wasm module</button>
         <div class="border">
             <h2>Function List</h2>
             <div id="functions" class="leftAlign"></div>

--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@ window.addEventListener("load", () => {
             const argElems = functionElems[expName];
             let args = [];
             for (let i = 0; i < expFunc.length; i++) {
-                const x = parseFloat(argElems[i].value);
+                const x = argElems[i].value;
                 args.push(x);
             }
             implib.outputBuf = "";

--- a/index.html
+++ b/index.html
@@ -32,6 +32,8 @@
 let obj;
 let implib;
 
+const useModule = false;
+
 window.addEventListener("load", () => {
     const consoleElem = document.getElementById("console");
     let outputBuf = "";
@@ -54,7 +56,15 @@ window.addEventListener("load", () => {
     (async () => {
         console.log("Loading wasm");
         try {
-            implib = await import("./wascal.js");
+            if (!useModule) {
+                const wascal = await fetch("./wascal.js");
+                const wascalSrc = await wascal.text();
+                implib = eval(wascalSrc);
+            }
+            else {
+                implib = await import("./wascal.js");
+            }
+            implib.init(fetch("wascal.wasm"));
         }
         catch(e) {
             consoleElem.innerHTML = e;

--- a/index.html
+++ b/index.html
@@ -30,19 +30,7 @@
         <script>
 
 let obj;
-
-function addStringToWasm(s) {
-    if (!obj) return;
-    const view32 = new Int32Array(obj.instance.exports.memory.buffer);
-    const top = view32[0];
-    const textEncoder = new TextEncoder('utf8');
-    const encodedString = textEncoder.encode(s);
-    const view8 = new Uint8Array(obj.instance.exports.memory.buffer, top + 4, encodedString.length);
-    view8.set(encodedString);
-    const newTop = top + Math.floor(encodedString.length + 3 / 4) * 4;
-    view32[0] = newTop;
-    return [top, encodedString.length];
-}
+let implib;
 
 window.addEventListener("load", () => {
     const consoleElem = document.getElementById("console");
@@ -63,13 +51,19 @@ window.addEventListener("load", () => {
     const load = document.getElementById("load");
     load.addEventListener("click", async () => {
         console.log("Loading wasm");
-        obj = await WebAssembly.instantiateStreaming(fetch("wascal.wasm"), opts);
+        try {
+            implib = await import("./wascal.js");
+        }
+        catch(e) {
+            consoleElem.innerHTML = e;
+        }
 
         const functions = document.getElementById("functions");
         while (functions.firstChild) functions.removeChild(functions.firstChild);
         functionElems = [];
-        for (let expName in obj.instance.exports) {
-            const expFunc = obj.instance.exports[expName];
+        for (let expName in implib) {
+            if (expName === "memory") continue;
+            const expFunc = implib[expName];
             const funcElem = document.createElement("div");
             const fNameElem = document.createTextNode(expName + "(");
             funcElem.appendChild(fNameElem);
@@ -101,29 +95,20 @@ window.addEventListener("load", () => {
     });
     
     const callFunc = expName => async () => {
-        const expFunc = obj.instance.exports[expName];
+        const expFunc = implib[expName];
         console.log("Calling wasm");
         outputBuf = "";
         const start = performance.now();
         try{
-            const addedString = addStringToWasm("Hello");
             const argElems = functionElems[expName];
             let args = [];
             for (let i = 0; i < expFunc.length; i++) {
-                if (expName !== "malloc" && i < 2) {
-                    args.push(addedString[i]);
-                }
-                else {
-                    const x = parseFloat(argElems[i].value);
-                    args.push(x);
-                }
+                const x = parseFloat(argElems[i].value);
+                args.push(x);
             }
             const output = document.getElementById('output');
             const res = expFunc.apply(this, args);
-            const view32 = new Int32Array(obj.instance.exports.memory.buffer, res + 4);
-            const textDecoder = new TextDecoder('utf-8');
-            const decoded = textDecoder.decode(view32);
-            output.innerHTML = decoded;
+            output.innerHTML = res;
         }
         catch(e){
             outputBuf = e;

--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@ window.addEventListener("load", () => {
         while (functions.firstChild) functions.removeChild(functions.firstChild);
         functionElems = [];
         for (let expName in implib) {
-            if (expName === "memory") continue;
+            if (0 <= ["init", "malloc", "set", "strcat"].indexOf(expName)) continue;
             const expFunc = implib[expName];
             if (typeof expFunc !== "function") continue;
             const funcElem = document.createElement("div");

--- a/index.html
+++ b/index.html
@@ -66,6 +66,7 @@ window.addEventListener("load", () => {
         for (let expName in implib) {
             if (expName === "memory") continue;
             const expFunc = implib[expName];
+            if (typeof expFunc !== "function") continue;
             const funcElem = document.createElement("div");
             const fNameElem = document.createTextNode(expName + "(");
             funcElem.appendChild(fNameElem);
@@ -99,7 +100,7 @@ window.addEventListener("load", () => {
     const callFunc = expName => async () => {
         const expFunc = implib[expName];
         console.log("Calling wasm");
-        outputBuf = "";
+        let outputBuf = "";
         const start = performance.now();
         try{
             const argElems = functionElems[expName];
@@ -108,9 +109,11 @@ window.addEventListener("load", () => {
                 const x = parseFloat(argElems[i].value);
                 args.push(x);
             }
+            implib.outputBuf = "";
             const output = document.getElementById('output');
             const res = expFunc.apply(this, args);
             output.innerHTML = res;
+            outputBuf = implib.outputBuf;
         }
         catch(e){
             outputBuf = e;

--- a/index.html
+++ b/index.html
@@ -31,6 +31,19 @@
 
 let obj;
 
+function addStringToWasm(s) {
+    if (!obj) return;
+    const view32 = new Int32Array(obj.instance.exports.memory.buffer);
+    const top = view32[0];
+    const textEncoder = new TextEncoder('utf8');
+    const encodedString = textEncoder.encode(s);
+    const view8 = new Uint8Array(obj.instance.exports.memory.buffer, top + 4, encodedString.length);
+    view8.set(encodedString);
+    const newTop = top + Math.floor(encodedString.length + 3 / 4) * 4;
+    view32[0] = newTop;
+    return [top, encodedString.length];
+}
+
 window.addEventListener("load", () => {
     const consoleElem = document.getElementById("console");
     let outputBuf = "";
@@ -90,17 +103,28 @@ window.addEventListener("load", () => {
     const callFunc = expName => async () => {
         const expFunc = obj.instance.exports[expName];
         console.log("Calling wasm");
-        const argElems = functionElems[expName];
-        let args = [];
-        for (let i = 0; i < expFunc.length; i++) {
-            const x = parseFloat(argElems[i].value);
-            args.push(x);
-        }
-        const output = document.getElementById('output');
-        const start = performance.now();
         outputBuf = "";
+        const start = performance.now();
         try{
-            output.innerHTML = expFunc.apply(this, args);
+            const addedString = addStringToWasm("Hello");
+            const argElems = functionElems[expName];
+            let args = [];
+            for (let i = 0; i < expFunc.length; i++) {
+                if (i < 2) {
+                    args.push(addedString[i]);
+                }
+                else {
+                    const x = parseFloat(argElems[i].value);
+                    args.push(x);
+                }
+            }
+            const output = document.getElementById('output');
+            const res = expFunc.apply(this, args);
+            const view32 = new Int32Array(obj.instance.exports.memory.buffer, res + 4, 2);
+            const strView = new Int8Array(obj.instance.exports.memory.buffer, view32[0] + 4, view32[1]);
+            const textDecoder = new TextDecoder('utf-8');
+            const decoded = textDecoder.decode(strView);
+            output.innerHTML = decoded;
         }
         catch(e){
             outputBuf = e;

--- a/index.html
+++ b/index.html
@@ -120,10 +120,9 @@ window.addEventListener("load", () => {
             }
             const output = document.getElementById('output');
             const res = expFunc.apply(this, args);
-            const view32 = new Int32Array(obj.instance.exports.memory.buffer, res + 4, 2);
-            const strView = new Int8Array(obj.instance.exports.memory.buffer, view32[0] + 4, view32[1]);
+            const view32 = new Int32Array(obj.instance.exports.memory.buffer, res + 4);
             const textDecoder = new TextDecoder('utf-8');
-            const decoded = textDecoder.decode(strView);
+            const decoded = textDecoder.decode(view32);
             output.innerHTML = decoded;
         }
         catch(e){

--- a/scripts/string.wscl
+++ b/scripts/string.wscl
@@ -1,3 +1,3 @@
 pub let main() -> str = {
-    "Hello, world!"
+    "Hello, " + "world!"
 }

--- a/scripts/string.wscl
+++ b/scripts/string.wscl
@@ -1,0 +1,9 @@
+pub let main(s: str) -> i32 = {
+    let out = malloc(23);
+    set(out, 72);
+    set(out + 1, 101);
+    set(out + 2, 108);
+    set(out + 3, 108);
+    set(out + 4, 111);
+    out
+}

--- a/scripts/string.wscl
+++ b/scripts/string.wscl
@@ -1,9 +1,3 @@
-pub let main(s: str) -> i32 = {
-    let out = malloc(23);
-    set(out, 72);
-    set(out + 1, 101);
-    set(out + 2, 108);
-    set(out + 3, 108);
-    set(out + 4, 111);
-    out
+pub let main() -> str = {
+    "Hello, world!"
 }

--- a/scripts/string.wscl
+++ b/scripts/string.wscl
@@ -1,3 +1,3 @@
 pub let main() -> str = {
-    "Hello, " + "world!"
+    "Hello, " + "world!" + " again!!"
 }

--- a/scripts/strrepeat.wscl
+++ b/scripts/strrepeat.wscl
@@ -1,6 +1,6 @@
 pub let strrepeat(s: str, num: i32) -> str = {
-    let ret = "";
-    for i in 0 to num {
+    let ret = s;
+    for i in 1 to num {
         ret = ret + s;
     }
     ret

--- a/scripts/strrepeat.wscl
+++ b/scripts/strrepeat.wscl
@@ -1,0 +1,7 @@
+pub let strrepeat(s: str, num: i32) -> str = {
+    let ret = "";
+    for i in 0 to num {
+        ret = ret + s;
+    }
+    ret
+}

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -750,10 +750,9 @@ impl<'a> Compiler<'a> {
             }
         }
         if let Some(last_stmt) = stmts.last() {
-            if ty.word_count() < last_ty.word_count() {
-                for _ in 0..last_ty.word_count() - ty.word_count() {
-                    self.code.push(OpCode::Drop as u8);
-                }
+            println!("last_ty: {last_ty}");
+            for _ in 0..last_ty.word_count() {
+                self.code.push(OpCode::Drop as u8);
             }
             last_ty = self.emit_stmt(last_stmt, ty)?;
         }

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -189,13 +189,7 @@ impl<'a> Compiler<'a> {
         const_table: &'a mut ConstTable,
         funcs: &'a mut Vec<FuncDef>,
     ) -> Self {
-        let mut locals = args;
-        if ret_ty == Type::Str {
-            locals.push(VarDecl {
-                name: "ret_buf".to_string(),
-                ty: Type::I32.into(),
-            });
-        }
+        let locals = args;
         Self {
             code: vec![],
             locals,
@@ -401,9 +395,8 @@ impl<'a> Compiler<'a> {
                 Ok(ret)
             }
             Expression::StrLiteral(s) => {
-                let (ptr, len) = self.const_table.add_const(s, s.as_bytes());
-                self.i32const(ptr as u32);
-                self.i32const(len as u32);
+                let str = self.const_table.add_str(s, s);
+                self.i32const(str as u32);
                 Ok(Type::Str)
             }
             Expression::Variable(name) => {
@@ -495,13 +488,7 @@ impl<'a> Compiler<'a> {
                     f32: OpCode::F32Add,
                     f64: OpCode::F64Add,
                     st: Some(Box::new(|this| {
-                        this.i32const(8);
-                        let ret_malloc_ty = this.call_func("malloc")?;
-                        let ret_buf_idx = this.add_local("", ret_malloc_ty);
-                        this.local_get(ret_buf_idx);
                         this.call_func("strcat")?;
-                        this.local_get(ret_buf_idx);
-                        this.i32load(4)?;
                         Ok(())
                     })),
                 },

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -36,14 +36,26 @@ pub(crate) enum OpCode {
     I32LtU = 0x49,
     I32GtS = 0x4a,
     I32GtU = 0x4b,
+    I32LeS = 0x4c,
+    I32LeU = 0x4d,
+    I32GeS = 0x4e,
+    I32GeU = 0x4f,
     I64LtS = 0x53,
     I64LtU = 0x54,
     I64GtS = 0x55,
     I64GtU = 0x56,
+    I64LeS = 0x57,
+    I64LeU = 0x58,
+    I64GeS = 0x59,
+    I64GeU = 0x5a,
     F32Lt = 0x5d,
     F32Gt = 0x5e,
+    F32Le = 0x5f,
+    F32Ge = 0x60,
     F64Lt = 0x63,
     F64Gt = 0x64,
+    F64Le = 0x65,
+    F64Ge = 0x66,
     I32Add = 0x6a,
     I32Sub = 0x6b,
     I32Mul = 0x6c,
@@ -118,14 +130,26 @@ impl_op_from!(
     I32LtU: "i32.lt_u",
     I32GtS: "i32.gt_s",
     I32GtU: "i32.gt_u",
+    I32LeS: "i32.le_s",
+    I32LeU: "i32.le_u",
+    I32GeS: "i32.ge_s",
+    I32GeU: "i32.ge_u",
     I64LtS: "i64.lt_s",
     I64LtU: "i64.lt_u",
     I64GtS: "i64.gt_s",
     I64GtU: "i64.gt_u",
+    I64LeS: "i64.le_s",
+    I64LeU: "i64.le_u",
+    I64GeS: "i64.ge_s",
+    I64GeU: "i64.ge_u",
     F32Lt: "f32.lt",
     F32Gt: "f32.gt",
+    F32Le: "f32.le",
+    F32Ge: "f32.ge",
     F64Lt: "f64.lt",
     F64Gt: "f64.gt",
+    F64Le: "f64.le",
+    F64Ge: "f64.ge",
     I32Add: "i32.add",
     I32Sub: "i32.sub",
     I32Mul: "i32.mul",
@@ -789,13 +813,13 @@ impl<'a> Compiler<'a> {
         self.code.push(Type::Void.code());
 
         // End condition
-        self.local_get(end);
         self.local_get(idx);
+        self.local_get(end);
         self.code.push(match iter_ty {
-            Type::I32 => OpCode::I32LtS,
-            Type::I64 => OpCode::I64LtS,
-            Type::F32 => OpCode::F32Lt,
-            Type::F64 => OpCode::F64Lt,
+            Type::I32 => OpCode::I32GeS,
+            Type::I64 => OpCode::I64GeS,
+            Type::F32 => OpCode::F32Ge,
+            Type::F64 => OpCode::F64Ge,
             _ => return Err("For loop iteration variable has void type".to_string()),
         } as u8);
         self.code.push(OpCode::BrIf as u8);
@@ -1009,12 +1033,14 @@ pub fn disasm(code: &[u8], f: &mut impl Write) -> std::io::Result<()> {
                 let arg = f64::from_le_bytes(buf);
                 writeln!(f, "{indent}f64.const {arg}")?;
             }
-            I32LtS | I32LtU | I32GtS | I32GtU | I32Add | I32Sub | I32Mul | I32DivS | I32And
-            | I64LtS | I64LtU | I64GtS | I64GtU | I64Add | I64Sub | I64Mul | I64DivS | F32Neg
-            | F32Lt | F32Gt | F32Add | F32Sub | F32Mul | F32Div | F64Neg | F64Lt | F64Gt
-            | F64Add | F64Sub | F64Mul | F64Div | I32WrapI64 | I32TruncF32S | I32TruncF64S
-            | I64ExtendI32S | I64TruncF32S | I64TruncF64S | F32ConvertI32S | F32ConvertI64S
-            | F32DemoteF64 | F64ConvertI32S | F64ConvertI64S | F64PromoteF32 => {
+            I32LtS | I32LtU | I32GtS | I32GtU | I32LeS | I32LeU | I32GeS | I32GeU | I32Add
+            | I32Sub | I32Mul | I32DivS | I32And | I64LtS | I64LtU | I64GtS | I64GtU | I64LeS
+            | I64LeU | I64GeS | I64GeU | I64Add | I64Sub | I64Mul | I64DivS | F32Neg | F32Lt
+            | F32Gt | F32Le | F32Ge | F32Add | F32Sub | F32Mul | F32Div | F64Neg | F64Lt
+            | F64Gt | F64Le | F64Ge | F64Add | F64Sub | F64Mul | F64Div | I32WrapI64
+            | I32TruncF32S | I32TruncF64S | I64ExtendI32S | I64TruncF32S | I64TruncF64S
+            | F32ConvertI32S | F32ConvertI64S | F32DemoteF64 | F64ConvertI32S | F64ConvertI64S
+            | F64PromoteF32 => {
                 writeln!(f, "{indent}{}", code.to_name())?;
             }
             End => {

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -207,7 +207,6 @@ impl<'a> Compiler<'a> {
         // encode_leb128(&mut self.code, 0).unwrap();
 
         let last = self.emit_stmts(ast, ty)?;
-        dbg!(&last);
 
         self.code.push(OpCode::End as u8);
         Ok(last)

--- a/src/compiler/malloc.rs
+++ b/src/compiler/malloc.rs
@@ -1,4 +1,4 @@
-use crate::{model::FuncDef, parser::VarDecl, FuncImport, FuncType, Type};
+use crate::{const_table::ConstTable, model::FuncDef, parser::VarDecl, FuncImport, FuncType, Type};
 
 use super::{Compiler, OpCode};
 
@@ -8,6 +8,7 @@ impl<'a> Compiler<'a> {
     pub fn malloc(
         types: &mut Vec<FuncType>,
         imports: &[FuncImport],
+        const_table: &mut ConstTable,
         funcs: &mut Vec<FuncDef>,
     ) -> Result<(usize, usize), String> {
         let malloc_ty = types.len();
@@ -21,6 +22,7 @@ impl<'a> Compiler<'a> {
             Type::I32,
             types,
             imports,
+            const_table,
             funcs,
         );
         compiler.local_get(0);

--- a/src/compiler/malloc.rs
+++ b/src/compiler/malloc.rs
@@ -1,0 +1,84 @@
+use crate::{model::FuncDef, parser::VarDecl, FuncImport, FuncType, Type};
+
+use super::{Compiler, OpCode};
+
+impl<'a> Compiler<'a> {
+    /// Define a function malloc, which allocates a block of heap memory
+    /// with the size given by the argument.
+    pub fn malloc(
+        types: &mut Vec<FuncType>,
+        imports: &[FuncImport],
+        funcs: &mut Vec<FuncDef>,
+    ) -> Result<(usize, usize), String> {
+        let malloc_ty = types.len();
+        types.push(Compiler::type_malloc());
+
+        let mut compiler = Compiler::new(
+            vec![VarDecl {
+                name: "len".to_string(),
+                ty: Type::I32.into(),
+            }],
+            Type::I32,
+            types,
+            imports,
+            funcs,
+        );
+        compiler.local_get(0);
+        let ret = compiler.codegen_malloc()?;
+        compiler.local_get(ret);
+        compiler.code.push(OpCode::End as u8);
+
+        let func = FuncDef {
+            name: "malloc".to_string(),
+            ty: malloc_ty,
+            locals: compiler.locals,
+            code: compiler.code,
+            public: true,
+        };
+
+        let malloc_fn = funcs.len();
+
+        funcs.push(func);
+
+        Ok((malloc_ty, malloc_fn))
+    }
+
+    fn type_malloc() -> FuncType {
+        FuncType {
+            params: vec![Type::I32],
+            results: vec![Type::I32],
+        }
+    }
+
+    /// Assumes there is a value length in i32 on top of the stack, returning local index storing the address of the new buffer
+    pub(super) fn codegen_malloc(&mut self) -> Result<usize, String> {
+        const ALLOC_ALIGN: u32 = 4;
+        let stashed = self.add_local("", Type::I32); // []
+
+        self.i32const(0); // [0]
+        self.i32load(0)?; // [mem[0]]
+        let start_addr = self.add_local("", Type::I32); // []
+
+        self.i32const(0); // [0]
+                          // self.local_get(stashed); // [0, stashed]
+
+        // Round the length up to 4 bytes for the next allocation
+        self.local_get(stashed);
+        self.i32const(ALLOC_ALIGN - 1);
+        self.code.push(OpCode::I32Add as u8);
+        self.i32const(ALLOC_ALIGN);
+        self.code.push(OpCode::I32DivS as u8);
+        self.i32const(ALLOC_ALIGN);
+        self.code.push(OpCode::I32Mul as u8);
+        // self.i32and(!(0x3));
+
+        self.i32const(0); // [0, stashed, 0]
+        self.i32load(0)?; // [0, stashed, mem[0]]
+
+        self.code.push(OpCode::I32Add as u8); // [0, stashed + mem[0]]
+
+        self.i32store(0)?; // []
+
+        Ok(start_addr)
+    }
+}

--- a/src/compiler/malloc.rs
+++ b/src/compiler/malloc.rs
@@ -14,17 +14,13 @@ impl<'a> Compiler<'a> {
         let malloc_ty = types.len();
         types.push(Compiler::type_malloc());
 
-        let mut compiler = Compiler::new(
-            vec![VarDecl {
-                name: "len".to_string(),
-                ty: Type::I32.into(),
-            }],
-            Type::I32,
-            types,
-            imports,
-            const_table,
-            funcs,
-        );
+        let args = vec![VarDecl {
+            name: "len".to_string(),
+            ty: Type::I32.into(),
+        }];
+        let num_args = args.len();
+
+        let mut compiler = Compiler::new(args, Type::I32, types, imports, const_table, funcs);
         compiler.local_get(0);
         let ret = compiler.codegen_malloc()?;
         compiler.local_get(ret);
@@ -33,6 +29,8 @@ impl<'a> Compiler<'a> {
         let func = FuncDef {
             name: "malloc".to_string(),
             ty: malloc_ty,
+            ret_ty: Type::I32,
+            args: num_args,
             locals: compiler.locals,
             code: compiler.code,
             public: true,

--- a/src/compiler/set.rs
+++ b/src/compiler/set.rs
@@ -1,4 +1,9 @@
-use crate::{model::FuncDef, parser::VarDecl, FuncImport, FuncType, Type};
+use crate::{
+    const_table::{self, ConstTable},
+    model::FuncDef,
+    parser::VarDecl,
+    FuncImport, FuncType, Type,
+};
 
 use super::{Compiler, OpCode};
 
@@ -7,6 +12,7 @@ impl<'a> Compiler<'a> {
     pub fn compile_set(
         types: &mut Vec<FuncType>,
         imports: &[FuncImport],
+        const_table: &mut ConstTable,
         funcs: &mut Vec<FuncDef>,
     ) -> Result<(usize, usize), String> {
         let set_ty = types.len();
@@ -26,6 +32,7 @@ impl<'a> Compiler<'a> {
             Type::Void,
             types,
             imports,
+            const_table,
             funcs,
         );
         compiler.codegen_set()?;

--- a/src/compiler/set.rs
+++ b/src/compiler/set.rs
@@ -1,9 +1,4 @@
-use crate::{
-    const_table::{self, ConstTable},
-    model::FuncDef,
-    parser::VarDecl,
-    FuncImport, FuncType, Type,
-};
+use crate::{const_table::ConstTable, model::FuncDef, parser::VarDecl, FuncImport, FuncType, Type};
 
 use super::{Compiler, OpCode};
 

--- a/src/compiler/set.rs
+++ b/src/compiler/set.rs
@@ -13,29 +13,27 @@ impl<'a> Compiler<'a> {
         let set_ty = types.len();
         types.push(Compiler::type_set());
 
-        let mut compiler = Compiler::new(
-            vec![
-                VarDecl {
-                    name: "ptr".to_string(),
-                    ty: Type::I32.into(),
-                },
-                VarDecl {
-                    name: "char".to_string(),
-                    ty: Type::I32.into(),
-                },
-            ],
-            Type::Void,
-            types,
-            imports,
-            const_table,
-            funcs,
-        );
+        let args = vec![
+            VarDecl {
+                name: "ptr".to_string(),
+                ty: Type::I32.into(),
+            },
+            VarDecl {
+                name: "char".to_string(),
+                ty: Type::I32.into(),
+            },
+        ];
+        let num_args = args.len();
+
+        let mut compiler = Compiler::new(args, Type::Void, types, imports, const_table, funcs);
         compiler.codegen_set()?;
         compiler.code.push(OpCode::End as u8);
 
         let func = FuncDef {
             name: "set".to_string(),
             ty: set_ty,
+            ret_ty: Type::Void,
+            args: num_args,
             locals: compiler.locals,
             code: compiler.code,
             public: true,

--- a/src/compiler/set.rs
+++ b/src/compiler/set.rs
@@ -1,0 +1,65 @@
+use crate::{model::FuncDef, parser::VarDecl, FuncImport, FuncType, Type};
+
+use super::{Compiler, OpCode};
+
+impl<'a> Compiler<'a> {
+    /// Define `set` standard library function, which sets a byte in the specified address of memory.
+    pub fn compile_set(
+        types: &mut Vec<FuncType>,
+        imports: &[FuncImport],
+        funcs: &mut Vec<FuncDef>,
+    ) -> Result<(usize, usize), String> {
+        let set_ty = types.len();
+        types.push(Compiler::type_set());
+
+        let mut compiler = Compiler::new(
+            vec![
+                VarDecl {
+                    name: "ptr".to_string(),
+                    ty: Type::I32.into(),
+                },
+                VarDecl {
+                    name: "char".to_string(),
+                    ty: Type::I32.into(),
+                },
+            ],
+            Type::Void,
+            types,
+            imports,
+            funcs,
+        );
+        compiler.codegen_set()?;
+        compiler.code.push(OpCode::End as u8);
+
+        let func = FuncDef {
+            name: "set".to_string(),
+            ty: set_ty,
+            locals: compiler.locals,
+            code: compiler.code,
+            public: true,
+        };
+
+        let set_fn = funcs.len();
+
+        funcs.push(func);
+
+        Ok((set_ty, set_fn))
+    }
+
+    fn type_set() -> FuncType {
+        FuncType {
+            params: vec![Type::I32, Type::I32],
+            results: vec![],
+        }
+    }
+
+    /// Assumes there is a value length in i32 on top of the stack, returning local index storing the address of the new buffer
+    pub(super) fn codegen_set(&mut self) -> Result<(), String> {
+        self.local_get(0);
+        self.i32const(4);
+        self.code.push(OpCode::I32Add as u8);
+        self.local_get(1);
+        self.i32store(0)?;
+        Ok(())
+    }
+}

--- a/src/compiler/strcat.rs
+++ b/src/compiler/strcat.rs
@@ -70,6 +70,8 @@ impl<'a> Compiler<'a> {
         let total_len = self.add_local("", Type::I32);
 
         self.local_get(total_len);
+        self.i32const(4);
+        self.code.push(OpCode::I32Add as u8);
         let malloc_ty = self.call_func("malloc")?;
         let new_ptr = self.add_local("", malloc_ty);
 

--- a/src/compiler/strcat.rs
+++ b/src/compiler/strcat.rs
@@ -13,29 +13,27 @@ impl<'a> Compiler<'a> {
         let set_ty = types.len();
         types.push(Compiler::type_strcat());
 
-        let mut compiler = Compiler::new(
-            vec![
-                VarDecl {
-                    name: "lhs".to_string(),
-                    ty: Type::I32.into(),
-                },
-                VarDecl {
-                    name: "rhs".to_string(),
-                    ty: Type::I32.into(),
-                },
-            ],
-            Type::Str,
-            types,
-            imports,
-            const_table,
-            funcs,
-        );
+        let args = vec![
+            VarDecl {
+                name: "lhs".to_string(),
+                ty: Type::Str.into(),
+            },
+            VarDecl {
+                name: "rhs".to_string(),
+                ty: Type::Str.into(),
+            },
+        ];
+        let num_args = args.len();
+
+        let mut compiler = Compiler::new(args, Type::Str, types, imports, const_table, funcs);
         compiler.codegen_strcat()?;
         compiler.code.push(OpCode::End as u8);
 
         let func = FuncDef {
             name: "strcat".to_string(),
             ty: set_ty,
+            ret_ty: Type::Str,
+            args: num_args,
             locals: compiler.locals,
             code: compiler.code,
             public: true,

--- a/src/compiler/strcat.rs
+++ b/src/compiler/strcat.rs
@@ -1,6 +1,6 @@
 use crate::{const_table::ConstTable, model::FuncDef, parser::VarDecl, FuncImport, FuncType, Type};
 
-use super::{Compiler, OpCode};
+use super::{encode_leb128, Compiler, OpCode};
 
 impl<'a> Compiler<'a> {
     /// Define `set` standard library function, which sets a byte in the specified address of memory.
@@ -16,19 +16,11 @@ impl<'a> Compiler<'a> {
         let mut compiler = Compiler::new(
             vec![
                 VarDecl {
-                    name: "lhs_ptr".to_string(),
+                    name: "lhs".to_string(),
                     ty: Type::I32.into(),
                 },
                 VarDecl {
-                    name: "lhs_len".to_string(),
-                    ty: Type::I32.into(),
-                },
-                VarDecl {
-                    name: "rhs_ptr".to_string(),
-                    ty: Type::I32.into(),
-                },
-                VarDecl {
-                    name: "rhs_len".to_string(),
+                    name: "rhs".to_string(),
                     ty: Type::I32.into(),
                 },
             ],
@@ -58,16 +50,22 @@ impl<'a> Compiler<'a> {
 
     fn type_strcat() -> FuncType {
         FuncType {
-            params: vec![Type::I32, Type::I32, Type::I32, Type::I32, Type::I32],
-            results: vec![],
+            params: vec![Type::I32, Type::I32],
+            results: vec![Type::I32],
         }
     }
 
-    /// Pop [lhs_ptr, lhs_len, rhs_ptr, rhs_len] from the stack, create a string concatenated, returns the address
+    /// Pop [lhs, rhs] from the stack, create a string concatenated, returns the address
     /// of newly created buffer.
     fn codegen_strcat(&mut self) -> Result<(), String> {
-        self.local_get(1); // [lhs_len]
-        self.local_get(3); // [lhs_len, rhs_len]
+        self.local_get(0); // [lhs]
+        self.i32load(4)?; // [lhs_len]
+        let lhs_len = self.add_local("", Type::I32);
+        self.local_get(1); // [lhs_len, rhs]
+        self.i32load(4)?; // [lhs_len, rhs_len]
+        let rhs_len = self.add_local("", Type::I32);
+        self.local_get(lhs_len);
+        self.local_get(rhs_len);
         self.code.push(OpCode::I32Add as u8); // [lhs_len + rhs_len]
         let total_len = self.add_local("", Type::I32);
 
@@ -75,37 +73,59 @@ impl<'a> Compiler<'a> {
         let malloc_ty = self.call_func("malloc")?;
         let new_ptr = self.add_local("", malloc_ty);
 
+        // Store total length at the beginning of buffer
+        self.local_get(new_ptr);
+        self.local_get(total_len);
+        self.i32store(4)?;
+
         self.i32const(0);
         let idx = self.add_local("", Type::I32);
 
-        self.emit_for_loop(idx, total_len, Type::I32, |this| {
+        self.emit_for_loop(idx, lhs_len, Type::I32, |this| {
             this.local_get(idx); // [idx]
-            this.local_get(0); // [idx, lhs_ptr]
+            this.local_get(0); // [idx, lhs]
 
-            this.code.push(OpCode::I32Add as u8); // [idx + lhs_ptr]
+            this.code.push(OpCode::I32Add as u8); // [idx + lhs]
 
-            this.i32load8_s(4)?; // [mem[idx + lhs_ptr]]
+            this.i32load8_s(8)?; // [mem[idx + lhs]]
             let data = this.add_local("", Type::I32); // []
 
             this.local_get(idx); // [idx]
-            this.local_get(new_ptr); // [idx + new_ptr]
+            this.local_get(new_ptr); // [idx, new_ptr]
             this.code.push(OpCode::I32Add as u8); // [idx + new_ptr]
-            this.local_get(data); // [idx + new_ptr, mem[idx + ptr]]
+            this.local_get(data); // [idx + new_ptr, mem[idx + lhs]]
 
-            this.i32store8(4)?; // []
+            this.i32store8(8)?; // []
 
             Ok(())
         })?;
 
-        // Store the result to return address
-        self.local_get(4);
-        self.local_get(new_ptr);
-        self.i32store(4)?;
+        self.i32const(0);
+        self.code.push(OpCode::LocalSet as u8);
+        encode_leb128(&mut self.code, idx as u32).unwrap();
 
-        // Store the result to return address + 4
-        self.local_get(4);
-        self.local_get(total_len);
-        self.i32store(8)?;
+        self.emit_for_loop(idx, rhs_len, Type::I32, |this| {
+            this.local_get(idx); // [idx]
+            this.local_get(1); // [idx, rhs]
+
+            this.code.push(OpCode::I32Add as u8); // [idx + rhs]
+
+            this.i32load8_s(8)?; // [mem[idx + rhs]]
+            let data = this.add_local("", Type::I32); // []
+
+            this.local_get(idx); // [idx]
+            this.local_get(new_ptr); // [idx, new_ptr]
+            this.code.push(OpCode::I32Add as u8); // [idx + new_ptr]
+            this.local_get(lhs_len); // [idx + new_ptr, lhs_len]
+            this.code.push(OpCode::I32Add as u8); // [idx + new_ptr + lhs_len]
+            this.local_get(data); // [idx + new_ptr + lhs_len, mem[idx + rhs]]
+
+            this.i32store8(8)?; // []
+
+            Ok(())
+        })?;
+
+        self.local_get(new_ptr);
         Ok(())
     }
 }

--- a/src/compiler/strcat.rs
+++ b/src/compiler/strcat.rs
@@ -57,10 +57,10 @@ impl<'a> Compiler<'a> {
     /// of newly created buffer.
     fn codegen_strcat(&mut self) -> Result<(), String> {
         self.local_get(0); // [lhs]
-        self.i32load(4)?; // [lhs_len]
+        self.i32load(0)?; // [lhs_len]
         let lhs_len = self.add_local("", Type::I32);
         self.local_get(1); // [lhs_len, rhs]
-        self.i32load(4)?; // [lhs_len, rhs_len]
+        self.i32load(0)?; // [lhs_len, rhs_len]
         let rhs_len = self.add_local("", Type::I32);
         self.local_get(lhs_len);
         self.local_get(rhs_len);
@@ -76,7 +76,7 @@ impl<'a> Compiler<'a> {
         // Store total length at the beginning of buffer
         self.local_get(new_ptr);
         self.local_get(total_len);
-        self.i32store(4)?;
+        self.i32store(0)?;
 
         self.i32const(0);
         let idx = self.add_local("", Type::I32);
@@ -87,7 +87,7 @@ impl<'a> Compiler<'a> {
 
             this.code.push(OpCode::I32Add as u8); // [idx + lhs]
 
-            this.i32load8_s(8)?; // [mem[idx + lhs]]
+            this.i32load8_s(4)?; // [mem[idx + lhs]]
             let data = this.add_local("", Type::I32); // []
 
             this.local_get(idx); // [idx]
@@ -95,7 +95,7 @@ impl<'a> Compiler<'a> {
             this.code.push(OpCode::I32Add as u8); // [idx + new_ptr]
             this.local_get(data); // [idx + new_ptr, mem[idx + lhs]]
 
-            this.i32store8(8)?; // []
+            this.i32store8(4)?; // []
 
             Ok(())
         })?;
@@ -110,7 +110,7 @@ impl<'a> Compiler<'a> {
 
             this.code.push(OpCode::I32Add as u8); // [idx + rhs]
 
-            this.i32load8_s(8)?; // [mem[idx + rhs]]
+            this.i32load8_s(4)?; // [mem[idx + rhs]]
             let data = this.add_local("", Type::I32); // []
 
             this.local_get(idx); // [idx]
@@ -120,7 +120,7 @@ impl<'a> Compiler<'a> {
             this.code.push(OpCode::I32Add as u8); // [idx + new_ptr + lhs_len]
             this.local_get(data); // [idx + new_ptr + lhs_len, mem[idx + rhs]]
 
-            this.i32store8(8)?; // []
+            this.i32store8(4)?; // []
 
             Ok(())
         })?;

--- a/src/compiler/strcat.rs
+++ b/src/compiler/strcat.rs
@@ -1,0 +1,111 @@
+use crate::{const_table::ConstTable, model::FuncDef, parser::VarDecl, FuncImport, FuncType, Type};
+
+use super::{Compiler, OpCode};
+
+impl<'a> Compiler<'a> {
+    /// Define `set` standard library function, which sets a byte in the specified address of memory.
+    pub fn compile_strcat(
+        types: &mut Vec<FuncType>,
+        imports: &[FuncImport],
+        const_table: &mut ConstTable,
+        funcs: &mut Vec<FuncDef>,
+    ) -> Result<(usize, usize), String> {
+        let set_ty = types.len();
+        types.push(Compiler::type_strcat());
+
+        let mut compiler = Compiler::new(
+            vec![
+                VarDecl {
+                    name: "lhs_ptr".to_string(),
+                    ty: Type::I32.into(),
+                },
+                VarDecl {
+                    name: "lhs_len".to_string(),
+                    ty: Type::I32.into(),
+                },
+                VarDecl {
+                    name: "rhs_ptr".to_string(),
+                    ty: Type::I32.into(),
+                },
+                VarDecl {
+                    name: "rhs_len".to_string(),
+                    ty: Type::I32.into(),
+                },
+            ],
+            Type::Str,
+            types,
+            imports,
+            const_table,
+            funcs,
+        );
+        compiler.codegen_strcat()?;
+        compiler.code.push(OpCode::End as u8);
+
+        let func = FuncDef {
+            name: "strcat".to_string(),
+            ty: set_ty,
+            locals: compiler.locals,
+            code: compiler.code,
+            public: true,
+        };
+
+        let set_fn = funcs.len();
+
+        funcs.push(func);
+
+        Ok((set_ty, set_fn))
+    }
+
+    fn type_strcat() -> FuncType {
+        FuncType {
+            params: vec![Type::I32, Type::I32, Type::I32, Type::I32, Type::I32],
+            results: vec![],
+        }
+    }
+
+    /// Pop [lhs_ptr, lhs_len, rhs_ptr, rhs_len] from the stack, create a string concatenated, returns the address
+    /// of newly created buffer.
+    fn codegen_strcat(&mut self) -> Result<(), String> {
+        self.local_get(1); // [lhs_len]
+        self.local_get(3); // [lhs_len, rhs_len]
+        self.code.push(OpCode::I32Add as u8); // [lhs_len + rhs_len]
+        let total_len = self.add_local("", Type::I32);
+
+        self.local_get(total_len);
+        let malloc_ty = self.call_func("malloc")?;
+        let new_ptr = self.add_local("", malloc_ty);
+
+        self.i32const(0);
+        let idx = self.add_local("", Type::I32);
+
+        self.emit_for_loop(idx, total_len, Type::I32, |this| {
+            this.local_get(idx); // [idx]
+            this.local_get(0); // [idx, lhs_ptr]
+
+            this.code.push(OpCode::I32Add as u8); // [idx + lhs_ptr]
+
+            this.i32load8_s(4)?; // [mem[idx + lhs_ptr]]
+            let data = this.add_local("", Type::I32); // []
+
+            this.local_get(idx); // [idx]
+            this.local_get(new_ptr); // [idx + new_ptr]
+            this.code.push(OpCode::I32Add as u8); // [idx + new_ptr]
+            this.local_get(data); // [idx + new_ptr, mem[idx + ptr]]
+
+            this.i32store8(4)?; // []
+
+            Ok(())
+        })?;
+
+        // Store the result to return address
+        self.local_get(4);
+        self.local_get(new_ptr);
+        self.i32store(4)?;
+
+        // Store the result to return address + 4
+        self.local_get(4);
+        self.local_get(total_len);
+        self.i32store(8)?;
+        Ok(())
+    }
+}

--- a/src/const_table.rs
+++ b/src/const_table.rs
@@ -24,6 +24,17 @@ impl ConstTable {
         ret
     }
 
+    /// Strings are encoded as [len, bytes...] unlike Rust, because in this way we can represent it with a pointer.
+    pub fn add_str(&mut self, name: impl Into<String>, value: &str) -> usize {
+        let ptr = self.buf.len() + self.base_addr;
+        self.buf
+            .extend_from_slice(&(value.len() as u32).to_le_bytes());
+        self.buf.extend_from_slice(value.as_bytes());
+        let ret = (ptr, value.len());
+        self.consts.insert(name.into(), ret);
+        ptr
+    }
+
     pub fn base_addr(&self) -> usize {
         self.base_addr + 4
     }

--- a/src/const_table.rs
+++ b/src/const_table.rs
@@ -25,7 +25,7 @@ impl ConstTable {
     }
 
     pub fn base_addr(&self) -> usize {
-        self.base_addr
+        self.base_addr + 4
     }
 
     pub fn data(&self) -> &[u8] {

--- a/src/const_table.rs
+++ b/src/const_table.rs
@@ -1,0 +1,34 @@
+use std::collections::HashMap;
+
+#[derive(Default)]
+pub(crate) struct ConstTable {
+    base_addr: usize,
+    buf: Vec<u8>,
+    /// Constant table, we would like to represent a slice into `buf`, but we cannot have self-referential structs.
+    consts: HashMap<String, (usize, usize)>,
+}
+
+impl ConstTable {
+    pub fn new() -> Self {
+        Self {
+            base_addr: 0x800,
+            ..Self::default()
+        }
+    }
+
+    pub fn add_const(&mut self, name: impl Into<String>, value: &[u8]) -> (usize, usize) {
+        let ptr = self.buf.len() + self.base_addr;
+        self.buf.extend_from_slice(value);
+        let ret = (ptr, value.len());
+        self.consts.insert(name.into(), ret);
+        ret
+    }
+
+    pub fn base_addr(&self) -> usize {
+        self.base_addr
+    }
+
+    pub fn data(&self) -> &[u8] {
+        &self.buf
+    }
+}

--- a/src/infer.rs
+++ b/src/infer.rs
@@ -4,7 +4,7 @@ use std::{collections::HashMap, io::Write};
 
 use crate::{
     model::{FuncDef, TypeSet},
-    parser::{format_params, format_stmt, Expression, Statement},
+    parser::{format_stmt, Expression, Statement},
     wasm_file::{CompileError, CompileResult},
     FuncImport, FuncType, Type,
 };

--- a/src/infer.rs
+++ b/src/infer.rs
@@ -82,6 +82,7 @@ impl<'a> TypeInferer<'a> {
         match ex {
             Expression::LiteralInt(_, ts) => Ok(*ts),
             Expression::LiteralFloat(_, ts) => Ok(*ts),
+            Expression::StrLiteral(_) => Ok(Type::Str.into()),
             Expression::Variable(name) => Ok(self
                 .locals
                 .get(*name)
@@ -124,6 +125,7 @@ impl<'a> TypeInferer<'a> {
         match ex {
             Expression::LiteralInt(_, target_ts) => *target_ts = *ts,
             Expression::LiteralFloat(_, target_ts) => *target_ts = *ts,
+            Expression::StrLiteral(_) => {}
             Expression::Variable(name) => {
                 if let Some(var) = self.locals.get_mut(*name) {
                     dprintln!("propagate variable {name}: {var} -> {ts}");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod compiler;
+mod const_table;
 mod infer;
 mod model;
 mod parser;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut f = std::io::BufWriter::new(std::fs::File::create("wascal.wasm")?);
 
     let mut file_name = "scripts/hello.wscl".to_string();
+    let mut bind_f = std::io::BufWriter::new(std::fs::File::create("wascal.js")?);
     let mut debug_type_infer = false;
     let mut enable_disasm = false;
     for arg in std::env::args().skip(1) {
@@ -49,6 +50,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     compile_wasm(
         &mut f,
+        &mut bind_f,
         &source,
         &mut types,
         &imports,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod compiler;
+mod const_table;
 mod infer;
 mod model;
 mod parser;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,10 +15,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut bind_f = std::io::BufWriter::new(std::fs::File::create("wascal.js")?);
     let mut debug_type_infer = false;
     let mut enable_disasm = false;
+    let mut bind_module = false;
     for arg in std::env::args().skip(1) {
         match &arg as &str {
             "-d" => debug_type_infer = true,
             "-D" => enable_disasm = true,
+            "-m" => bind_module = true,
             _ => file_name = arg,
         }
     }
@@ -51,6 +53,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     compile_wasm(
         &mut f,
         &mut bind_f,
+        bind_module,
         &source,
         &mut types,
         &imports,

--- a/src/model.rs
+++ b/src/model.rs
@@ -248,6 +248,7 @@ pub struct FuncImport {
 pub(crate) struct FuncDef {
     pub name: String,
     pub ty: usize,
+    /// The number of arguments as first n locals
     pub args: usize,
     pub ret_ty: Type,
     pub code: Vec<u8>,

--- a/src/model.rs
+++ b/src/model.rs
@@ -248,6 +248,8 @@ pub struct FuncImport {
 pub(crate) struct FuncDef {
     pub name: String,
     pub ty: usize,
+    pub args: usize,
+    pub ret_ty: Type,
     pub code: Vec<u8>,
     pub locals: Vec<VarDecl>,
     pub public: bool,

--- a/src/model.rs
+++ b/src/model.rs
@@ -8,6 +8,7 @@ pub enum Type {
     F64,
     // Pseudo type representing no value
     Void,
+    Str,
 }
 
 impl Type {
@@ -18,6 +19,8 @@ impl Type {
             Self::F32 => 0x7d,
             Self::F64 => 0x7c,
             Self::Void => 0x40,
+            // Str is a compound type, so it does not have a code.
+            Self::Str => 0x0,
         }
     }
 }
@@ -58,6 +61,7 @@ impl std::fmt::Display for Type {
             Self::F32 => write!(f, "f32"),
             Self::F64 => write!(f, "f64"),
             Self::Void => write!(f, "void"),
+            Self::Str => write!(f, "str"),
         }
     }
 }
@@ -69,6 +73,7 @@ pub struct TypeSet {
     pub f32: bool,
     pub f64: bool,
     pub void: bool,
+    pub st: bool,
 }
 
 impl TypeSet {
@@ -78,6 +83,7 @@ impl TypeSet {
         f32: false,
         f64: false,
         void: false,
+        st: false,
     };
     pub const I64: Self = Self {
         i32: false,
@@ -85,6 +91,7 @@ impl TypeSet {
         f32: false,
         f64: false,
         void: false,
+        st: false,
     };
     pub const F32: Self = Self {
         i32: false,
@@ -92,6 +99,7 @@ impl TypeSet {
         f32: true,
         f64: false,
         void: false,
+        st: false,
     };
     pub const F64: Self = Self {
         i32: false,
@@ -99,6 +107,23 @@ impl TypeSet {
         f32: false,
         f64: true,
         void: false,
+        st: false,
+    };
+    pub const VOID: Self = Self {
+        i32: false,
+        i64: false,
+        f32: false,
+        f64: false,
+        void: true,
+        st: false,
+    };
+    pub const STR: Self = Self {
+        i32: false,
+        i64: false,
+        f32: false,
+        f64: false,
+        void: false,
+        st: true,
     };
     pub const ALL: Self = Self {
         i32: true,
@@ -106,6 +131,7 @@ impl TypeSet {
         f32: true,
         f64: true,
         void: true,
+        st: false,
     };
 
     pub fn is_none(&self) -> bool {
@@ -114,41 +140,12 @@ impl TypeSet {
 
     pub fn determine(&self) -> Option<Type> {
         match self {
-            TypeSet {
-                i32: true,
-                i64: false,
-                f32: false,
-                f64: false,
-                void: false,
-            } => Some(Type::I32),
-            TypeSet {
-                i32: false,
-                i64: true,
-                f32: false,
-                f64: false,
-                void: false,
-            } => Some(Type::I64),
-            TypeSet {
-                i32: false,
-                i64: false,
-                f32: true,
-                f64: false,
-                void: false,
-            } => Some(Type::F32),
-            TypeSet {
-                i32: false,
-                i64: false,
-                f32: false,
-                f64: true,
-                void: false,
-            } => Some(Type::F64),
-            TypeSet {
-                i32: false,
-                i64: false,
-                f32: false,
-                f64: false,
-                void: true,
-            } => Some(Type::Void),
+            &Self::I32 => Some(Type::I32),
+            &Self::I64 => Some(Type::I64),
+            &Self::F32 => Some(Type::F32),
+            &Self::F64 => Some(Type::F64),
+            &Self::VOID => Some(Type::Void),
+            &Self::STR => Some(Type::Str),
             _ => None,
         }
     }
@@ -163,6 +160,7 @@ impl std::ops::BitOr for TypeSet {
             f32: self.f32 | rhs.f32,
             f64: self.f64 | rhs.f64,
             void: self.void | rhs.void,
+            st: self.st | rhs.st,
         }
     }
 }
@@ -176,6 +174,7 @@ impl std::ops::BitAnd for TypeSet {
             f32: self.f32 & rhs.f32,
             f64: self.f64 & rhs.f64,
             void: self.void & rhs.void,
+            st: self.st & rhs.st,
         }
     }
 }
@@ -189,6 +188,7 @@ impl From<Type> for TypeSet {
             Type::F32 => ret.f32 = true,
             Type::F64 => ret.f64 = true,
             Type::Void => ret.void = true,
+            Type::Str => ret.st = true,
         }
         ret
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -19,8 +19,8 @@ impl Type {
             Self::F32 => 0x7d,
             Self::F64 => 0x7c,
             Self::Void => 0x40,
-            // Str is a compound type, so it does not have a code.
-            Self::Str => 0x0,
+            // Str is a compound type, but it is returned as an i32 pointing the buffer.
+            Self::Str => 0x7f,
         }
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -29,8 +29,7 @@ impl Type {
     /// has 2 words (a pointer and a size), and Void type has 0 words.
     pub(crate) fn word_count(&self) -> usize {
         match self {
-            Self::Str => 2,
-            Self::I32 | Self::I64 | Self::F32 | Self::F64 => 1,
+            Self::Str | Self::I32 | Self::I64 | Self::F32 | Self::F64 => 1,
             Self::Void => 0,
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,6 +4,7 @@ use crate::model::{Type, TypeSet};
 pub enum Expression<'src> {
     LiteralInt(i64, TypeSet),
     LiteralFloat(f64, TypeSet),
+    StrLiteral(String),
     Variable(&'src str),
     FnInvoke(&'src str, Vec<Expression<'src>>),
     Cast(Box<Expression<'src>>, Type),
@@ -84,6 +85,34 @@ fn num_literal(mut input: &str) -> Result<(&str, Expression), String> {
     } else {
         Err("Not a number".to_string())
     }
+}
+
+fn str_literal(i: &str) -> IResult<&str, Expression> {
+    let (r0, _) = recognize("\"")(space(i))?;
+    let mut r = r0;
+
+    let mut escaped = false;
+    let mut buf = String::new();
+    loop {
+        let Some(c) = peek_char(r) else {
+            return Err("Unclosed string".to_string());
+        };
+        r = advance_char(r);
+        if !escaped && c == '\"' {
+            break;
+        }
+        if (c == '\\') ^ !escaped {
+            buf.push(c);
+        }
+        escaped = c == '\\';
+    }
+
+    let val = &r0[..r.as_ptr() as usize - r0.as_ptr() as usize - 1];
+
+    Ok((
+        r,
+        Expression::StrLiteral(val.to_string().replace("\\\\", "\\").replace("\\n", "\n")),
+    ))
 }
 
 #[test]
@@ -204,6 +233,10 @@ fn factor(i: &str) -> Result<(&str, Expression), String> {
     if let Ok((r, _)) = recognize("-")(r) {
         let (r, val) = factor(r)?;
         return Ok((r, Expression::Neg(Box::new(val))));
+    }
+
+    if let Ok((r, str)) = str_literal(r) {
+        return Ok((r, str));
     }
 
     if let Ok((r, _)) = recognize("(")(r) {
@@ -557,6 +590,7 @@ pub fn format_expr(
     match ex {
         Expression::LiteralFloat(num, ts) => write!(f, "{num}: {ts}"),
         Expression::LiteralInt(num, ts) => write!(f, "{num}: {ts}"),
+        Expression::StrLiteral(s) => write!(f, "\"{s}\""), // TODO: escape
         Expression::Variable(name) => write!(f, "{name}"),
         Expression::FnInvoke(fname, args) => {
             write!(f, "{fname}(")?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -653,12 +653,7 @@ pub fn format_stmt(
         Statement::FnDecl(func) => {
             let public = if func.public { "pub " } else { "" };
             write!(f, "{public}let {}(", func.name)?;
-            for (i, param) in func.params.iter().enumerate() {
-                write!(f, "{}: {}", param.name, param.ty)?;
-                if i != func.params.len() - 1 {
-                    write!(f, ", ")?;
-                }
-            }
+            format_params(&func.params, f)?;
             write!(f, ") -> {} =", func.ret_ty)?;
             for stmt in &func.stmts {
                 format_stmt(stmt, level + 1, f)?;
@@ -686,4 +681,14 @@ pub fn format_stmt(
             writeln!(f, ";")
         }
     }
+}
+
+pub fn format_params(params: &[VarDecl], f: &mut impl std::io::Write) -> std::io::Result<()> {
+    for (i, param) in params.iter().enumerate() {
+        write!(f, "{}: {}", param.name, param.ty)?;
+        if i != params.len() - 1 {
+            write!(f, ", ")?;
+        }
+    }
+    Ok(())
 }

--- a/src/wasm_file.rs
+++ b/src/wasm_file.rs
@@ -229,11 +229,24 @@ fn codegen(
         }
 
         if func.public {
-            let js_args = args.into_iter().fold("".to_string(), |acc, cur| {
+            let js_args = args.iter().fold("".to_string(), |acc, cur| {
                 if acc.is_empty() {
                     cur.name.clone()
                 } else {
                     acc + ", " + &cur.name
+                }
+            });
+
+            let wasm_args = args.iter().fold("".to_string(), |acc, cur| {
+                let arg = if cur.ty == Type::Str.into() {
+                    format!("addStringToWasm({})", cur.name)
+                } else {
+                    format!("parseFloat({})", cur.name)
+                };
+                if acc.is_empty() {
+                    arg
+                } else {
+                    acc + ", " + &arg
                 }
             });
 
@@ -246,7 +259,7 @@ fn codegen(
             writeln!(
                 bind,
                 r#"export function {}({js_args}) {{
-    const ret = obj.instance.exports.{}({js_args});
+    const ret = obj.instance.exports.{}({wasm_args});
     return {return_filter}(ret);
 }}"#,
                 func.name, func.name

--- a/src/wasm_file.rs
+++ b/src/wasm_file.rs
@@ -227,14 +227,22 @@ fn codegen(
             disasm_func(&func, &func_ty, disasm_f)?;
         }
 
-        writeln!(
-            bind,
-            r#"export function {}() {{
+        if func.public {
+            let return_filter = if ret_ty == Type::Str {
+                "returnString"
+            } else {
+                ""
+            };
+
+            writeln!(
+                bind,
+                r#"export function {}() {{
     const ret = obj.instance.exports.{}();
-    return returnString(ret);
+    return {return_filter}(ret);
 }}"#,
-            func.name, func.name
-        )?;
+                func.name, func.name
+            )?;
+        }
     }
 
     Ok((funcs, const_table))

--- a/src/wasm_file.rs
+++ b/src/wasm_file.rs
@@ -118,6 +118,17 @@ fn codegen(
         disasm_func(&funcs[malloc_fn], &func_ty, disasm_f)?;
     }
 
+    let (set_ty, set_fn) =
+        Compiler::compile_set(types, imports, &mut funcs).map_err(|e| CompileError::Compile(e))?;
+
+    if let Some(ref mut disasm_f) = disasm_f {
+        let func_ty = &types[set_ty];
+
+        disasm_func(&funcs[set_fn], &func_ty, disasm_f)?;
+    }
+
+    let std_fns = funcs.len();
+
     println!("functions before type infer:");
     for func in &funcs {
         println!("  {}", func.name);
@@ -208,7 +219,7 @@ fn codegen(
         let code = compiler.get_code().to_vec();
         let locals = compiler.get_locals().to_vec();
 
-        let func = &mut funcs[i + 1];
+        let func = &mut funcs[i + std_fns];
         func.code = code;
         func.locals = locals;
 

--- a/src/wasm_file.rs
+++ b/src/wasm_file.rs
@@ -101,6 +101,7 @@ fn write_bind(bind: &mut impl Write, module: bool, funcs: &[FuncDef]) -> std::io
                 .replace("export async function init", "module.init = async function")
                 .replace("memory =", "module.memory =")
                 .replace("export let memory;", "module.memory = {};")
+                .replace("export let outputBuf = \"\";", "module.outputBuf = \"\";")
         )?;
     } else {
         writeln!(bind, "{}", HEADER)?;

--- a/src/wasm_file.rs
+++ b/src/wasm_file.rs
@@ -118,11 +118,16 @@ fn codegen(
         disasm_func(&funcs[malloc_fn], &func_ty, disasm_f)?;
     }
 
+    println!("functions before type infer:");
+    for func in &funcs {
+        println!("  {}", func.name);
+    }
+
     let mut stmts = parse(&source).map_err(|e| CompileError::Compile(e))?;
 
     set_infer_debug(debug_type_infer);
 
-    run_type_infer(&mut stmts, types, imports, typeinf_f)?;
+    run_type_infer(&mut stmts, types, imports, &funcs, typeinf_f)?;
 
     fn find_funcs<'a>(stmts: &'a [Statement<'a>], funcs: &mut Vec<&FnDecl<'a>>) {
         for stmt in stmts.iter() {

--- a/src/wasm_file.rs
+++ b/src/wasm_file.rs
@@ -43,7 +43,7 @@ impl From<std::io::Error> for CompileError {
 
 pub type CompileResult<T> = Result<T, CompileError>;
 
-/// `bind_module` indicates whether to use ES2015 module for binding JS code.
+/// `bind_module` indicates whether to use ES6 module for binding JS code.
 pub fn compile_wasm(
     f: &mut impl Write,
     bind: &mut impl Write,
@@ -87,7 +87,7 @@ pub fn compile_wasm(
 }
 
 /// Write a JS binding code, similar to wasm-bindgen does for Rust.
-/// `module` flag indicates whether the output JS code should be a ES2015 module or an IIFE.
+/// `module` flag indicates whether the output JS code should be a ES6 module or an IIFE.
 fn write_bind(bind: &mut impl Write, module: bool, funcs: &[FuncDef]) -> std::io::Result<()> {
     // Include boilerplate code for binding
     const HEADER: &str = include_str!("../header.js");

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -96,6 +96,36 @@
 
             <h2>Syntax</h2>
             The syntax is inspired a bit by functional languages, although the execution model is imperative.
+
+            <h3>Literals</h3>
+            <p>
+            Digits without a decimal points are abstract integers, which is either i32 or i64.
+            The concrete type will be determined by type inference.
+            Therefore, a integer literal without using will be an error with an ambiguous type.
+            </p>
+
+            <pre>
+42
+            </pre>
+
+            <p>
+            Digits with a decimal points are abstract floats, which is either f32 or f64.
+            The concrete type will be determined by type inference.
+            Therefore, a float literal without using will be an error with an ambiguous type.
+            </p>
+
+<pre>
+3.14
+</pre>
+
+            <p>
+            String literals are double quoted.
+            </p>
+
+<pre>
+"Hello"
+</pre>
+
             <h3>Variable declaration</h3>
             <p>
                 Variables are declared with <tt>let</tt> keyword like below.

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -65,7 +65,7 @@
 
         <div class="justify">
             <h2>Data types</h2>
-            WebAssembly has only 4 primitive types.
+            WebAssembly has only 4 primitive types, but we have a custom type for strings.
             You can declare variables and function arguments in a syntax like <tt>a: type</tt>
             or <tt>let f(a: type) -> type</tt>.
             <tt>type</tt> can be one of:
@@ -74,16 +74,20 @@
                 <li>i64</li>
                 <li>f32</li>
                 <li>f64</li>
+                <li>str</li>
             </ul>
 
             <p>
-            Yes, there are no string types!
-            Since we do not use linear memory yet, we can't handle variable length data, including a string.
+            String type requires linear memory and a heap memory allocator.
+            We use a bump allocator that constantly leaks memory, so don't use too much memory.
             </p>
 
             <h2>Built-in functions</h2>
 
             <ul>
+            <li>malloc(size: i32) - Allocates heap memory block with the given size and return a pointer to it.</li>
+            <li>set(ptr: i32, c: i32) - Sets a memory byte at given address. A low level function that end users shouldn't use.</li>
+            <li>strcat(lhs: str, rhs: str) - Standard library function that is used to concatenate strings. Uses should use + operator between strings.</li>
             <li>log(value: i32) - Prints a value to JavaScript console (console.log).</li>
             <li>putc(char: i32) - Puts a single character, specified by ascii code, to the output console.</li>
             <li>set_fill_style(r: i32, g: i32, b: i32) - Sets fill color for painting on the canvas.</li>

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,8 +1,6 @@
 use wasm_bindgen::prelude::*;
 
-use wascal::{
-    compile_wasm, disasm_wasm, typeinf_wasm, FuncImport, FuncType, Type,
-};
+use wascal::{compile_wasm, disasm_wasm, typeinf_wasm, FuncImport, FuncType, Type};
 
 #[wasm_bindgen]
 pub fn parse_ast(source: &str) -> Result<String, JsValue> {
@@ -14,12 +12,26 @@ pub fn parse_ast(source: &str) -> Result<String, JsValue> {
 }
 
 #[wasm_bindgen]
-pub fn compile(source: &str) -> Result<Vec<u8>, JsValue> {
+pub fn compile(source: &str) -> Result<JsValue, JsValue> {
     let (mut types, imports) = default_imports();
-    let mut buf = vec![];
-    compile_wasm(&mut buf, source, &mut types, &imports, None, None, false)
-        .map_err(|e| JsValue::from(format!("{e}")))?;
-    Ok(buf)
+    let mut wasm_buf = vec![];
+    let mut bind_buf = vec![];
+    compile_wasm(
+        &mut wasm_buf,
+        &mut bind_buf,
+        false,
+        source,
+        &mut types,
+        &imports,
+        None,
+        None,
+        false,
+    )
+    .map_err(|e| JsValue::from(format!("{e}")))?;
+    let bind_str = String::from_utf8(bind_buf).map_err(|e| JsValue::from(format!("{e}")))?;
+    let ret =
+        JsValue::from(Box::new([JsValue::from(wasm_buf), JsValue::from(bind_str)]) as Box<[_]>);
+    Ok(ret)
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
Now you can use string as a type. It is named `str` in the code:

```
pub let cat(a: str, b: str) -> str = a + b;
```
 
Currently, the only operation allowed is to concatenate two strings with `+` operator.

# Linear Memory

From this feature, we introduce the linear memory.
Since strings are dynamically sized, we need heap memory to allocate them, which is achieved by the linear memory provided by Wasm runtime.

## Memory layout

The linear memory is layed out like below.

```
+-----+-----+-----+-----+
| top |  const table    |
+-----+-----+-----+-----+
| const table cont.     |
+-----+-----+-----+-----+
| ...                   |
+-----+-----+-----+-----+
| Heap                  |
+-----+-----+-----+-----+
```

First comes is the 4-byte `top` pointer, which indicates the next chunk of memory that will be used for heap memory block.
The next is constant table, which is a static data (such as string literals) that are known at compile time.
After the constant table is the heap.

## Allocator

We use a bump allocator for now, because it's the easiest to implement.
It means you will leak memory for every instance of strings, so do not use strings too much.
Of course we will implement free and realloc in later PRs.

## String memory layout

We use length-data encoding for strings.
A pointer to a string should point to the first byte of the length.
Therefore, you need to add 4 to the pointer to access the actual string contents.
The payload is not null-terminated.

```
+--------+----------------------+
| length | payload...           |
+--------+----------------------+
```

## The difference from Rust strings

It is different from Rust's, which is `(ptr, len, capacity)` triples, because it's a pain to maintain composite type in the Wasm stack.
Rust's wasm compiler uses its own stack in linear memory, which is probably what we should go with.

# Standard library

We implement few functions as standard library to manage the heap memory.
They are implemented in Wasm bytecode, so it is analogous to libc for C, not the system calls.

## malloc

Obviously, we need a function to allocate a block of mamory.
`malloc` has the same interface as C standard. It takes a memory size in bytes and returns the pointer to the block.
The pointer is rounded to multiple of 4 bytes, which is the alignment of  i32.

## set

A utility function to set a byte at any address in linear memory.
It is not actively used but provided as a debug tool.

## strcat

One of the simplest operations on a string, which is to make a new string by concatenating the arguments.
It is used by `+` operator on strings.

# Binding code

Since we use i32 to point to heap allocated data, the Wasm type signature no longer conveys its semantics.
The user of the Wasm should have access to logic to interpret returned values or how to allocate and pass the string to wasm in arguments.
This is achieved by binding code generated at the same time as the Wasm binary, similar to wasm-bindgen for Rust.

For example, in the example code of `cat` function, a binding like below (and some other helper functions) will be generated.

```js
export function cat(lhs, rhs) {
    const ret = obj.instance.exports.strcat(addStringToWasm(lhs), addStringToWasm(rhs));
    return returnString(ret);
}
```

The arguments are pre-processed appropriately, for example, in case of a string argument, it is passed to `addStringToWasm`, which does how it sounds.
The returned value is also converted from Wasm pointer that points to heap memory to JS string in the helper function `returnString`.

The binding code is generated with the name `wascal.js` but it will follow the name of the main wasm module later.

## Modules vs IIFE

Binding code can be generated as a ES6 module or a IIFE source text.
In general, modules should be preferred, because it's safer, but in some cases (such as dynamic imports with Webpack) it does not work, so IIFE can save you in that case.

In the command line interface, giving `-m` option will enable ES6 module.