### PR TITLE
Implement linear memory stack and alloca function to allocate memory

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@ window.addEventListener("load", () => {
         while (functions.firstChild) functions.removeChild(functions.firstChild);
         functionElems = [];
         for (let expName in implib.exports) {
-            if (0 <= ["malloc", "set", "strcat", "reverse", "sqrt"].indexOf(expName)) continue;
+            if (0 <= ["alloca", "malloc", "set", "strcat", "reverse", "sqrt"].indexOf(expName)) continue;
             const expFunc = implib.exports[expName];
             if (typeof expFunc !== "function") continue;
             const funcElem = document.createElement("div");

--- a/scripts/loop.wscl
+++ b/scripts/loop.wscl
@@ -7,4 +7,4 @@ let loop(x: i64) -> i32 = {
     ret as i32
 }
 
-pub let main(x: i32) -> i32 = loop(x as i64);
+pub let main(x: i32) -> i32 = loop(x as i64)

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -10,6 +10,8 @@ mod strcat;
 
 use std::{collections::HashMap, io::Write};
 
+use count_stack::set_debug_count_stack;
+
 use self::emit::{to_load, to_store};
 
 use crate::{
@@ -256,6 +258,7 @@ pub struct Compiler<'a> {
     base_offset: usize,
     /// The size of the linear memory stack, in bytes, not to be confused with the locals
     stack_size: usize,
+    debug_count_stack: bool,
 }
 
 impl<'a> Compiler<'a> {
@@ -295,13 +298,21 @@ impl<'a> Compiler<'a> {
             base_ptr: 0,
             base_offset: 0,
             stack_size: 0,
+            debug_count_stack: false,
         })
     }
 
+    pub fn debug_count_stack(&mut self, v: bool) {
+        self.debug_count_stack = v;
+    }
+
     pub fn compile(&mut self, ast: &[Statement], ty: Type) -> Result<Type, String> {
+        set_debug_count_stack(self.debug_count_stack);
         self.stack_size = self.count_stack_stmts(ast)?;
 
-        println!("stack size is {}", self.stack_size);
+        if self.debug_count_stack {
+            println!("stack size is {}", self.stack_size);
+        }
 
         if 0 < self.stack_size {
             // Remember base pointer, the address of the top of the stack before calling this function.

--- a/src/compiler/alloca.rs
+++ b/src/compiler/alloca.rs
@@ -1,0 +1,106 @@
+use std::collections::HashMap;
+
+use crate::{const_table::ConstTable, model::FuncDef, parser::VarDecl, FuncImport, FuncType, Type};
+
+use super::{Compiler, OpCode};
+
+impl<'a> Compiler<'a> {
+    /// Define a function malloc, which allocates a block of heap memory
+    /// with the size given by the argument.
+    pub fn alloca(
+        types: &mut Vec<FuncType>,
+        imports: &[FuncImport],
+        const_table: &mut ConstTable,
+        funcs: &mut Vec<FuncDef>,
+    ) -> Result<(usize, usize), String> {
+        let malloc_ty = types.len();
+        types.push(FuncType {
+            params: vec![Type::I32],
+            results: vec![Type::I32],
+        });
+
+        let args = vec![VarDecl {
+            name: "len".to_string(),
+            ty: Type::I32.into(),
+        }];
+        let num_args = args.len();
+
+        let structs = HashMap::new();
+
+        let mut compiler = Compiler::new(
+            args,
+            Type::I32,
+            types,
+            imports,
+            const_table,
+            funcs,
+            &structs,
+        );
+        compiler.local_get(0);
+        let ret = compiler.codegen_alloca()?;
+        compiler.local_get(ret);
+        compiler.code.push(OpCode::End as u8);
+
+        let func = FuncDef {
+            name: "alloca".to_string(),
+            ty: malloc_ty,
+            ret_ty: Type::I32,
+            args: num_args,
+            locals: compiler.locals,
+            code: compiler.code,
+            public: true,
+        };
+
+        let malloc_fn = funcs.len();
+
+        funcs.push(func);
+
+        Ok((malloc_ty, malloc_fn))
+    }
+
+    /// Assumes there is a value length in i32 on top of the stack, returning local index storing the address of the new buffer
+    pub(super) fn codegen_alloca(&mut self) -> Result<usize, String> {
+        const ALLOC_ALIGN: u32 = 4;
+        let stashed = self.add_local("", Type::I32); // []
+
+        // Get stack pointer
+        self.i32const(4); // [4]
+        self.i32load(0)?; // [mem[4]]
+        let start_addr = self.add_local("", Type::I32); // []
+
+        self.i32const(4); // [0]
+
+        // Round the length up to 4 bytes for the next allocation
+        self.local_get(stashed);
+        self.i32const(ALLOC_ALIGN - 1);
+        self.code.push(OpCode::I32Add as u8);
+        self.i32const(ALLOC_ALIGN);
+        self.code.push(OpCode::I32DivU as u8);
+        self.i32const(ALLOC_ALIGN);
+        self.code.push(OpCode::I32Mul as u8); // [4, rounded_size = (stashed - 3) / 4 * 4]
+        self.local_get(start_addr); // [4, rounded_size, start_addr]
+        self.code.push(OpCode::I32Add as u8); // [4, new_size = rounded_size + start_addr]
+        let new_size = self.add_local("", Type::I32);
+
+        self.local_get(new_size);
+        self.i32store(0)?;
+
+        self.local_get(new_size);
+        self.i32const(65536);
+        self.code.push(OpCode::I32DivU as u8);
+        self.code.push(OpCode::MemorySize as u8);
+        self.code.push(0);
+        self.code.push(OpCode::I32GeU as u8);
+        self.code.push(OpCode::If as u8);
+        self.code.push(Type::Void.code());
+        self.local_get(new_size);
+        self.i32const(65536);
+        self.code.push(OpCode::I32DivS as u8);
+        self.code.push(OpCode::MemoryGrow as u8);
+        self.code.push(0);
+        self.code.push(OpCode::Drop as u8);
+        self.code.push(OpCode::End as u8);
+
+        Ok(start_addr)
+    }
+}

--- a/src/compiler/alloca.rs
+++ b/src/compiler/alloca.rs
@@ -35,7 +35,7 @@ impl<'a> Compiler<'a> {
             const_table,
             funcs,
             &structs,
-        );
+        )?;
         compiler.local_get(0);
         let ret = compiler.codegen_alloca()?;
         compiler.local_get(ret);

--- a/src/compiler/count_stack.rs
+++ b/src/compiler/count_stack.rs
@@ -20,11 +20,13 @@ impl<'a> Compiler<'a> {
                     return Err(format!("Struct {stname} not found"));
                 };
 
-                println!("String literal size {}", stdef.size);
+                println!("Struct literal {stname} size {}", stdef.size);
 
                 let mut stack_size = stdef.size;
-                for (_, field) in fields {
-                    stack_size += self.count_stack_expr(field)?;
+                for (fname, field) in fields {
+                    let field_sz = self.count_stack_expr(field)?;
+                    println!("Struct field {fname} size {field_sz}");
+                    stack_size += field_sz;
                 }
                 stack_size
             }

--- a/src/compiler/count_stack.rs
+++ b/src/compiler/count_stack.rs
@@ -1,0 +1,230 @@
+//! Methods to calculate the size of the linear memory stack (not wasm operand stack!).
+//! It has to exactly match the logic of emit_*, otherwise stack overflow can occur.
+
+use crate::{
+    parser::{Expression, Statement},
+    Type,
+};
+
+use super::Compiler;
+
+impl<'a> Compiler<'a> {
+    fn count_stack_expr(&mut self, ast: &Expression) -> Result<usize, String> {
+        use Expression::*;
+        Ok(match ast {
+            LiteralInt(_, _) | LiteralFloat(_, _) => 0,
+            // String literals are baked into constant table, so it doesn't count in the stack.
+            StrLiteral(_) => 0,
+            StructLiteral(stname, fields) => {
+                let Some(stdef) = self.structs.get(*stname) else {
+                    return Err(format!("Struct {stname} not found"));
+                };
+
+                println!("String literal size {}", stdef.size);
+
+                let mut stack_size = stdef.size;
+                for (_, field) in fields {
+                    stack_size += self.count_stack_expr(field)?;
+                }
+                stack_size
+            }
+            // Referencing a variable does not cost a stack.
+            Variable(_) => 0,
+            FnInvoke(fname, args) => {
+                let mut stack_size = 0;
+                for arg in args {
+                    stack_size += self.count_stack_expr(arg)?;
+                }
+
+                let (_, ret_ty, _) = self
+                    .find_func(fname)
+                    .ok_or_else(|| format!("Calling undefined function {fname}"))?;
+
+                println!("count_stack: Calling function {}", fname);
+
+                if let Some(stname) = ret_ty.struct_name() {
+                    let st = self
+                        .structs
+                        .get(stname)
+                        .ok_or_else(|| format!("Struct {stname} not found"))?;
+                    println!("Adding struct {stname} size {}", st.size);
+                    stack_size += st.size;
+                }
+
+                stack_size
+            }
+            Cast(ex, _ty) => self.count_stack_expr(ex)?,
+            FieldAccess(ex, _fname) => self.count_stack_expr(ex)?,
+            // TODO: operator overloading for neg
+            Neg(ex) => self.count_stack_expr(ex)?,
+            Add(lhs, rhs) => self.count_stack_bin_op(lhs, rhs, "add")?,
+            Sub(lhs, rhs) => self.count_stack_bin_op(lhs, rhs, "sub")?,
+            Mul(lhs, rhs) => self.count_stack_bin_op(lhs, rhs, "mul")?,
+            Div(lhs, rhs) => self.count_stack_bin_op(lhs, rhs, "div")?,
+            // We assume logical operators use primitive i32, which consumes no linear memory stack.
+            // TODO: operator overloading for comparison operators
+            And(_, _) | Or(_, _) | Gt(_, _) | Lt(_, _) => 0,
+            Conditional(cond, t_branch, f_branch) => {
+                let mut stack_size =
+                    self.count_stack_expr(cond)? + self.count_stack_stmts(t_branch)?;
+                if let Some(stmts) = f_branch {
+                    stack_size += self.count_stack_stmts(stmts)?;
+                }
+                stack_size
+            }
+        })
+    }
+
+    fn type_expr(&self, ex: &Expression) -> Result<Type, String> {
+        use Expression::*;
+        Ok(match ex {
+            LiteralInt(_, ts) | LiteralFloat(_, ts) => ts
+                .determine()
+                .ok_or_else(|| format!("Literal type could not be determined: {ts}"))?,
+            StrLiteral(_) => Type::Str,
+            StructLiteral(stname, _fields) => Type::Struct(stname.to_string()),
+            Variable(vname) => self
+                .local_ty
+                .get(*vname)
+                .ok_or_else(|| format!("Variable {vname} not found"))?
+                .clone(),
+            FnInvoke(fname, _args) => {
+                let (_, ret_ty, _) = self
+                    .find_func(fname)
+                    .ok_or_else(|| format!("Calling undefined function {fname}"))?;
+                ret_ty
+            }
+            Cast(_, ty) => ty.clone(),
+            FieldAccess(ex, fname) => {
+                let ty = self.type_expr(ex)?;
+                let Type::Struct(stname) = ty else {
+                    return Err("Field access operator got non-struct".to_string());
+                };
+                let st = self
+                    .structs
+                    .get(&stname)
+                    .ok_or_else(|| format!("Struct {} not found", stname))?;
+                st.fields
+                    .iter()
+                    .find_map(|field| {
+                        if field.name == *fname {
+                            Some(field.ty.clone())
+                        } else {
+                            None
+                        }
+                    })
+                    .ok_or_else(|| format!("Field {fname} not found"))?
+            }
+            // TODO: operator overloading for neg
+            Neg(ex) => self.type_expr(ex)?,
+            Add(lhs, _rhs) => self.type_expr(lhs)?,
+            Sub(lhs, _rhs) => self.type_expr(lhs)?,
+            Mul(lhs, _rhs) => self.type_expr(lhs)?,
+            Div(lhs, _rhs) => self.type_expr(lhs)?,
+            // We assume logical operators use primitive i32, which consumes no linear memory stack.
+            // TODO: operator overloading for comparison operators
+            And(_, _) | Or(_, _) | Gt(_, _) | Lt(_, _) => Type::I32,
+            Conditional(_, t_branch, _) => t_branch
+                .last()
+                .map_or(Ok(Type::Void), |stmt| self.type_stmt(stmt))?,
+        })
+    }
+
+    fn type_stmt(&self, stmt: &Statement) -> Result<Type, String> {
+        use Statement::*;
+        Ok(match stmt {
+            VarDecl(_, _, _) | VarAssign(_, _) | Struct(_) | FnDecl(_) | For(_) => Type::Void,
+            Expr(ex, _) => self.type_expr(ex)?,
+            Brace(stmts) => stmts
+                .last()
+                .map_or(Ok(Type::Void), |stmt| self.type_stmt(stmt))?,
+            Return(ex) => ex
+                .as_ref()
+                .map_or(Ok(Type::Void), |ex| self.type_expr(ex))?,
+        })
+    }
+
+    fn count_stack_bin_op(
+        &mut self,
+        lhs: &Expression,
+        rhs: &Expression,
+        name: &str,
+    ) -> Result<usize, String> {
+        let lhs_sz = self.count_stack_expr(lhs)?;
+        let lhs_ty = self.type_expr(lhs)?;
+        let rhs_sz = self.count_stack_expr(rhs)?;
+        let rhs_ty = self.type_expr(rhs)?;
+
+        // If either side of the expression has a type that requires linear memory stack,
+        // we should call operator overloading function
+        Ok(match (&lhs_ty, &rhs_ty) {
+            (Type::Struct(_), Type::Struct(_)) => {
+                let dunder = format!("__{name}__");
+                let (_, ret_ty, _) = self
+                    .find_func(&dunder)
+                    .ok_or_else(|| format!("Calling undefined function {}", dunder))?;
+
+                println!(
+                    "count_stack: Calling function {} adding stack size {}",
+                    dunder,
+                    lhs_sz + rhs_sz
+                );
+
+                let mut stack_size = lhs_sz + rhs_sz;
+
+                // Reserve stack space for returned value
+                if let Some(stname) = ret_ty.struct_name() {
+                    let st = self
+                        .structs
+                        .get(stname)
+                        .ok_or_else(|| format!("Struct {stname} not found"))?;
+                    stack_size += st.size;
+                }
+
+                stack_size
+            }
+            _ => lhs_sz + rhs_sz,
+        })
+    }
+
+    fn count_stack_stmt(&mut self, stmt: &Statement) -> Result<usize, String> {
+        use Statement::*;
+        Ok(match stmt {
+            VarDecl(name, ty, ex) => {
+                // Variable declaration actually won't consume stack, because it just stores a point to it
+                // in Wasm locals.
+                let stack_size = self.count_stack_expr(ex)?;
+
+                self.local_ty.insert(
+                    name.to_string(),
+                    ty.determine()
+                        .ok_or_else(|| format!("Type could not be determined {ty}"))?,
+                );
+
+                stack_size
+            }
+            // Similarly, lvalue expression does not consume stack, because it returns i32 pointing to the address
+            VarAssign(_, ex) => self.count_stack_expr(ex)?,
+            Expr(ex, _) => self.count_stack_expr(ex)?,
+            FnDecl(_) => 0,
+            For(for_stmt) => {
+                self.local_ty
+                    .insert(for_stmt.name.to_string(), self.type_expr(&for_stmt.start)?);
+                self.count_stack_expr(&for_stmt.start)?
+                    + self.count_stack_expr(&for_stmt.end)?
+                    + self.count_stack_stmts(&for_stmt.stmts)?
+            }
+            Brace(stmts) => self.count_stack_stmts(stmts)?,
+            Return(ex) => ex.as_ref().map_or(Ok(0), |ex| self.count_stack_expr(ex))?,
+            Struct(_) => 0,
+        })
+    }
+
+    pub(super) fn count_stack_stmts(&mut self, stmts: &[Statement]) -> Result<usize, String> {
+        let mut stack_size = 0;
+        for stmt in stmts {
+            stack_size += self.count_stack_stmt(stmt)?;
+        }
+        Ok(stack_size)
+    }
+}

--- a/src/compiler/emit.rs
+++ b/src/compiler/emit.rs
@@ -16,18 +16,19 @@ impl<'a> Compiler<'a> {
         encode_sleb128(&mut self.code, val as i32).unwrap();
     }
 
-    pub(super) fn i32load(&mut self, offset: u32) -> Result<(), String> {
-        self.code.push(OpCode::I32Load as u8);
+    pub(super) fn load(&mut self, op: OpCode, offset: u32) -> Result<(), String> {
+        self.code.push(op as u8);
         encode_leb128(&mut self.code, 0).unwrap();
         encode_leb128(&mut self.code, offset).unwrap();
         Ok(())
     }
 
+    pub(super) fn i32load(&mut self, offset: u32) -> Result<(), String> {
+        self.load(OpCode::I32Load, offset)
+    }
+
     pub(super) fn i32load8_s(&mut self, offset: u32) -> Result<(), String> {
-        self.code.push(OpCode::I32Load8S as u8);
-        encode_leb128(&mut self.code, 0).unwrap();
-        encode_leb128(&mut self.code, offset).unwrap();
-        Ok(())
+        self.load(OpCode::I32Load8S, offset)
     }
 
     pub(super) fn store(&mut self, op: OpCode, offset: u32) -> Result<(), String> {
@@ -69,4 +70,26 @@ impl<'a> Compiler<'a> {
         encode_leb128(&mut self.code, field.offset as u32).unwrap();
         Ok(field.ty.clone())
     }
+}
+
+pub(super) fn to_load(ty: &Type) -> Option<OpCode> {
+    Some(match ty {
+        Type::I32 => OpCode::I32Load,
+        Type::I64 => OpCode::I64Load,
+        Type::F32 => OpCode::F32Load,
+        Type::F64 => OpCode::F64Load,
+        Type::Void => return None,
+        Type::Str | Type::Struct(_) => OpCode::I32Load,
+    })
+}
+
+pub(super) fn to_store(ty: &Type) -> Option<OpCode> {
+    Some(match ty {
+        Type::I32 => OpCode::I32Store,
+        Type::I64 => OpCode::I64Store,
+        Type::F32 => OpCode::F32Store,
+        Type::F64 => OpCode::F64Store,
+        Type::Void => return None,
+        Type::Str | Type::Struct(_) => OpCode::I32Store,
+    })
 }

--- a/src/compiler/malloc.rs
+++ b/src/compiler/malloc.rs
@@ -32,7 +32,7 @@ impl<'a> Compiler<'a> {
             const_table,
             funcs,
             &structs,
-        );
+        )?;
         compiler.local_get(0);
         let ret = compiler.codegen_malloc()?;
         compiler.local_get(ret);

--- a/src/compiler/reverse.rs
+++ b/src/compiler/reverse.rs
@@ -35,7 +35,7 @@ impl<'a> Compiler<'a> {
             const_table,
             funcs,
             &structs,
-        );
+        )?;
         compiler.codegen_reverse()?;
         compiler.code.push(OpCode::End as u8);
 

--- a/src/compiler/set.rs
+++ b/src/compiler/set.rs
@@ -37,7 +37,7 @@ impl<'a> Compiler<'a> {
             const_table,
             funcs,
             &structs,
-        );
+        )?;
         compiler.codegen_set()?;
         compiler.code.push(OpCode::End as u8);
 

--- a/src/compiler/sqrt.rs
+++ b/src/compiler/sqrt.rs
@@ -34,7 +34,7 @@ impl<'a> Compiler<'a> {
             const_table,
             funcs,
             &structs,
-        );
+        )?;
         compiler.codegen_sqrt()?;
         compiler.code.push(OpCode::End as u8);
 

--- a/src/compiler/strcat.rs
+++ b/src/compiler/strcat.rs
@@ -37,7 +37,7 @@ impl<'a> Compiler<'a> {
             const_table,
             funcs,
             &structs,
-        );
+        )?;
         compiler.codegen_strcat()?;
         compiler.code.push(OpCode::End as u8);
 

--- a/src/const_table.rs
+++ b/src/const_table.rs
@@ -9,8 +9,10 @@ pub(crate) struct ConstTable {
 }
 
 const PTR_SIZE: usize = std::mem::size_of::<i32>();
-// Use half of the first page for the stack. Probably not enough for general purpose.
-const STACK_SIZE: usize = 1024 * 32;
+// We should allocate enough pages to contain the stack.
+pub(crate) const INITIAL_PAGES: u32 = 16;
+// Use one minus total pages for the stack.
+const STACK_SIZE: usize = 1024 * 64 * (INITIAL_PAGES as usize - 1);
 
 impl ConstTable {
     pub fn new() -> Self {

--- a/src/const_table.rs
+++ b/src/const_table.rs
@@ -9,10 +9,15 @@ pub(crate) struct ConstTable {
 }
 
 const PTR_SIZE: usize = std::mem::size_of::<i32>();
+// Use half of the first page for the stack. Probably not enough for general purpose.
+const STACK_SIZE: usize = 1024 * 32;
 
 impl ConstTable {
     pub fn new() -> Self {
         let mut buf = vec![];
+        // The first word is the starting address of the bump allocator.
+        buf.extend_from_slice(&0u32.to_le_bytes());
+        // The second word is the stack pointer
         buf.extend_from_slice(&0u32.to_le_bytes());
         Self {
             base_addr: 0,
@@ -57,8 +62,10 @@ impl ConstTable {
             self.buf
                 .resize((self.buf.len() + PTR_SIZE - 1) / PTR_SIZE * PTR_SIZE, 0u8);
         }
+        let bytes = ((self.buf.len() + STACK_SIZE) as u32).to_le_bytes();
+        self.buf[..PTR_SIZE].copy_from_slice(&bytes); // heap pointer
         let bytes = (self.buf.len() as u32).to_le_bytes();
-        self.buf[..PTR_SIZE].copy_from_slice(&bytes);
+        self.buf[PTR_SIZE..PTR_SIZE * 2].copy_from_slice(&bytes); // stack pointer
     }
 
     pub fn print_data(&self, f: &mut impl Write) -> std::io::Result<()> {

--- a/src/infer.rs
+++ b/src/infer.rs
@@ -4,7 +4,7 @@ use std::{collections::HashMap, io::Write};
 
 use crate::{
     model::{FuncDef, StructDef, TypeSet},
-    parser::{format_expr, format_stmt, Expression, Statement},
+    parser::{format_stmt, Expression, Statement},
     wasm_file::{CompileError, CompileResult},
     FuncImport, FuncType, Type,
 };

--- a/src/leb128.rs
+++ b/src/leb128.rs
@@ -63,6 +63,7 @@ pub(crate) fn decode_leb128(f: &mut impl Read) -> std::io::Result<i32> {
     }
 }
 
+#[allow(dead_code)]
 pub(crate) fn decode_sleb128(f: &mut impl Read) -> std::io::Result<i32> {
     let mut value = 0u32;
     let mut shift = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,5 +9,5 @@ mod wasm_file;
 pub use crate::{
     model::{FuncImport, FuncType, Type},
     parser::{format_expr, format_stmt, parse},
-    wasm_file::{compile_wasm, default_imports, default_types, disasm_wasm, typeinf_wasm},
+    wasm_file::{default_imports, default_types, disasm_wasm, typeinf_wasm, WasmCompiler},
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ mod parser;
 mod wasm_file;
 
 use model::{FuncImport, FuncType, Type};
-use wasm_file::{compile_wasm, default_imports, default_types};
+use wasm_file::{default_imports, default_types, WasmCompiler};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut f = std::io::BufWriter::new(std::fs::File::create("wascal.wasm")?);
@@ -15,11 +15,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut file_name = "scripts/hello.wscl".to_string();
     let mut bind_f = std::io::BufWriter::new(std::fs::File::create("wascal.js")?);
     let mut debug_type_infer = false;
+    let mut debug_count_stack = false;
     let mut enable_disasm = false;
     let mut bind_module = false;
     for arg in std::env::args().skip(1) {
         match &arg as &str {
             "-d" => debug_type_infer = true,
+            "-C" => debug_count_stack = true,
             "-D" => enable_disasm = true,
             "-m" => bind_module = true,
             _ => file_name = arg,
@@ -28,25 +30,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let source = std::fs::read_to_string(file_name)?;
 
-    let mut types = default_types();
+    let types = default_types();
     let imports = default_imports();
 
-    let mut disasm_f = if enable_disasm {
-        Some(std::io::stdout())
-    } else {
-        None
-    };
-    compile_wasm(
-        &mut f,
-        &mut bind_f,
-        bind_module,
-        &source,
-        &mut types,
-        &imports,
-        disasm_f.as_mut().map(|p| p as &mut dyn std::io::Write),
-        Some(&mut std::io::stdout()),
-        debug_type_infer,
-    )?;
+    let mut wasm_compiler = WasmCompiler::new(&source, types, imports)
+        .bind_module(bind_module)
+        .debug_count_stack(debug_count_stack);
+    let mut stdout = std::io::stdout();
+    if enable_disasm {
+        wasm_compiler = wasm_compiler.disasm_f(&mut stdout);
+    }
+    let mut stdout = std::io::stdout();
+    if debug_type_infer {
+        wasm_compiler = wasm_compiler.typeinf_f(&mut stdout).debug_type_infer(true);
+    }
+
+    wasm_compiler.compile_wasm(&mut f, &mut bind_f)?;
 
     Ok(())
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -49,6 +49,13 @@ impl Type {
             Self::Void => 0,
         }
     }
+
+    pub(crate) fn struct_name(&self) -> Option<&String> {
+        match self {
+            Self::Struct(stname) => Some(stname),
+            _ => None,
+        }
+    }
 }
 
 impl From<u8> for Type {

--- a/src/wasm_file.rs
+++ b/src/wasm_file.rs
@@ -625,6 +625,10 @@ pub fn default_types() -> Vec<FuncType> {
             params: vec![Type::F64],
             results: vec![Type::Str],
         },
+        FuncType {
+            params: vec![Type::Str],
+            results: vec![],
+        },
     ]
 }
 
@@ -638,7 +642,7 @@ pub fn default_imports() -> Vec<FuncImport> {
         FuncImport {
             module: "output".to_string(),
             name: "print".to_string(),
-            ty: 0,
+            ty: 2,
         },
         FuncImport {
             module: "output".to_string(),

--- a/src/wasm_file.rs
+++ b/src/wasm_file.rs
@@ -308,7 +308,8 @@ fn codegen(
             &mut const_table,
             &mut funcs,
             &structs,
-        );
+        )
+        .map_err(CompileError::Compile)?;
         if let Err(e) = compiler.compile(&func_stmt.stmts, ret_ty) {
             return Err(CompileError::Compile(format!(
                 "Error in compiling function {}: {e}",

--- a/src/wasm_file.rs
+++ b/src/wasm_file.rs
@@ -1,7 +1,7 @@
 //! Code to write wasm file format sections.
 use crate::{
     compiler::{disasm_func, Compiler, OpCode},
-    const_table::ConstTable,
+    const_table::{ConstTable, INITIAL_PAGES},
     infer::{run_type_infer, set_infer_debug},
     leb128::encode_leb128,
     model::{FuncDef, FuncImport, FuncType, StructDef},
@@ -577,7 +577,6 @@ fn export_section(funcs: &[FuncDef], imports: &[FuncImport]) -> std::io::Result<
 
 fn memory_section() -> std::io::Result<Vec<u8>> {
     const NO_LIMIT: u8 = 0u8;
-    const INITIAL_PAGES: u32 = 1;
 
     let mut buf = vec![];
     encode_leb128(&mut buf, 1)?;

--- a/wasm/js/main.js
+++ b/wasm/js/main.js
@@ -105,7 +105,7 @@ document.getElementById("compile").addEventListener("click", () => runCommon(asy
     console.log(`bind: ${Object.getOwnPropertyNames(bind.exports)}`);
     for (const expName in bind.exports) {
         // Skip useless functions from UI
-        if (0 <= ["malloc", "set", "strcat", "reverse", "sqrt"].indexOf(expName)) continue;
+        if (0 <= ["alloca", "malloc", "set", "strcat", "reverse", "sqrt"].indexOf(expName)) continue;
         const expFunc = bind.exports[expName];
         if (typeof expFunc !== "function") continue;
         const funcElem = document.createElement("div");


### PR DESCRIPTION
So far, we had malloc which constantly leaked memory. It worked for short lived processes, but we would like more efficient memory management. Even if the computer has enough physical memory, it can run out of 32bit memory space (4GB) before not too long.

Here comes the stack allocator, which is basically what actual CPU uses for function stack frames. It is as simple as adding the size to the stack pointer to allocate, and subtract to free. The stack pointer is reserved to the second word (4-8 bytes) of the linear memory, since Wasm runtime doesn't have a dedicated register for the stack pointer.

We could use a global to manage the stack pointer, but I felt like doing it all in the linear memory.

If a function uses any structs, it will call `alloca` at the beginning of the function to allocate the stack memory. If it doesn't, it won't add overhead to the function.

# Returning a struct

Wasm functions can only return a primitive type, so we cannot return structs or any composed values from a function. Even if it could, it would be very inefficient to copy all the data in the struct to returned stack.

Therefore, our calling convention for the struct is that the caller must allocate the struct to be returned and pass a pointer to it as the last implicit argument. For example a function like this:

```
let add(a: Vec2, b: Vec2) -> Vec2 = Vec2 {
    x: a.x + b:x, y: a.y + b.y
}
```

will be turned into 

```
let add(a: Vec2, b: Vev2, result: Vec2) -> void = {
    result.x = a.x + b.x;
    result.y = a.y + b.y;
}
```

and calls to this function will implicitly make a temporary variable to pass to the 3rd argument of this function.

This is very similar to actual CPU calling conventions.

However, we do not have RVO (return value optimization) yet, so the above code actually makes a temporary in the callee and copy it to the one in the caller. But this should be optimized in coming PRs.

# Memory layout

Now the memory layout has changed to this

```
+-----+-----+-----+-----+
| top |  sp | c. table  |
+-----+-----+-----+-----+
| const table cont.     |
+-----+-----+-----+-----+
| ...                   |
+-----+-----+-----+-----+
| stack                 |
|    |                  |
|    V                  |
+-----+-----+-----+-----+ <- stack pointer
|                       |
+-----+-----+-----+-----+
| Heap                  |
+-----+-----+-----+-----+
```

Historically, many ISAs stack grows in negative direction, but our stack grows in positive side.

You can see that the stack pointer can collide with the heap, if you allocate too much stack memory.
Currently, the stack memory is fixed to 496KB.

# Limitations

We still need malloc for variable size memory, that is, only the string in current language. It still leaks, so we need proper memory management after all.
